### PR TITLE
Example: Sensor download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: build
 build:
 	$(GOBUILD) ./...
 
-generate: specs/swagger-stripped-oauth.json
+generate: specs/swagger-download-patch.json
 	$(GO) run github.com/go-swagger/go-swagger/cmd/swagger generate client --skip-validation -f $^ -t falcon
 
 .PHONY: build generate
@@ -18,6 +18,10 @@ specs/swagger-stripped-oauth.json: specs/swagger-formatted.json
 	# We remove security info from swagger before generating golang API interface.
 	# This achieves cleaner interface. OAuth is then applied automatically through the middle-ware.
 	jq 'walk(if type == "object" and has("security") and (has("consumes") or has("produces")) then del(.security) else . end)' $< > $@
+
+specs/swagger-download-patch.json: specs/swagger-stripped-oauth.json
+	# We add missing binary response body spec to the swagger
+	jq '.definitions."domain.DownloadItem"."type"="string" | .definitions."domain.DownloadItem"."format"="binary"' $< > $@
 
 specs/swagger.json:
 	@echo "Sorry swagger.json needs to be obtained manually at this moment"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/crowdstrike/gofalcon/falcon"
-	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
+	"github.com/crowdstrike/gofalcon/falcon/client/incidents"
 )
 
 func main() {

--- a/examples/sensor_download/main.go
+++ b/examples/sensor_download/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/crowdstrike/gofalcon/falcon"
+	"github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
+	"github.com/crowdstrike/gofalcon/falcon/models"
+)
+
+func main() {
+	clientId := flag.String("client-id", os.Getenv("FALCON_CLIENT_ID"), "Client ID for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_ID env)")
+	clientSecret := flag.String("client-secret", os.Getenv("FALCON_CLIENT_SECRET"), "Client Secret for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_SECRET)")
+	osName := flag.String("os-name", "", "Name of the operating system")
+	osVersion := flag.String("os-version", "", "Versin of the operating system")
+
+	flag.Parse()
+
+	if *clientId == "" {
+		fmt.Printf("Please provide your Falcon Client ID: ")
+		_, err := fmt.Scanln(clientId)
+		if err != nil {
+			panic(err)
+		}
+	}
+	if *clientSecret == "" {
+		fmt.Printf("Please provide your Falcon Client Secret: ")
+		_, err := fmt.Scanln(clientSecret)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	client, err := falcon.NewClient(&falcon.ApiConfig{
+		ClientId:     *clientId,
+		ClientSecret: *clientSecret,
+		Context:      context.Background(),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	if *osName == "" {
+		validOsNames := getValidOsNames(client)
+		fmt.Printf("Missing --os-name command-line option. Valid names are: [%s]\n", strings.Join(validOsNames, ","))
+		fmt.Printf("Selected OS Name: ")
+		_, err := fmt.Scanln(osName)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	if *osVersion == "" {
+		validOsVersions := getValidOsVersions(client, *osName)
+		if len(validOsVersions) == 0 {
+			fmt.Fprintf(os.Stderr, "No sensors available for os: %s\n", *osName)
+			os.Exit(1)
+		}
+		fmt.Printf("Missing --os-version command-line option. Valid version are: %s\n", validOsVersions)
+		fmt.Printf("Selected OS Version: ")
+		_, err := fmt.Scanln(osVersion)
+		if err != nil {
+			panic(err)
+		}
+	}
+	sensor := querySuitableSensor(client, *osName, *osVersion)
+	if sensor == nil {
+		fmt.Fprintf(os.Stderr, "Could not find relevant sensor for '%s' version '%s'\n", *osName, *osVersion)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Downloading %s to %s\n", *sensor.Description, *sensor.Name)
+
+	download(client, sensor)
+}
+
+func download(client *client.CrowdStrikeAPISpecification, sensor *models.DomainSensorInstallerV1) {
+	file, err := os.OpenFile(*sensor.Name, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = client.SensorDownload.DownloadSensorInstallerByID(
+		&sensor_download.DownloadSensorInstallerByIDParams{
+			Context: context.Background(),
+			ID:      *sensor.Sha256,
+		}, file)
+	if err != nil {
+		falcon.ErrorExplain(err)
+	}
+	fmt.Println("OK")
+
+}
+
+func querySuitableSensor(client *client.CrowdStrikeAPISpecification, osName, osVersion string) *models.DomainSensorInstallerV1 {
+	for _, sensor := range getSensors(client, osName) {
+		if osVersion == *sensor.OsVersion {
+			return sensor
+		}
+	}
+	return nil
+}
+
+func getSensors(client *client.CrowdStrikeAPISpecification, osName string) []*models.DomainSensorInstallerV1 {
+	var filter *string
+	if osName != "" {
+		f := fmt.Sprintf("os:\"%s\"", osName)
+		filter = &f
+	}
+	res, err := client.SensorDownload.GetCombinedSensorInstallersByQuery(
+		&sensor_download.GetCombinedSensorInstallersByQueryParams{
+			Context: context.Background(),
+			Filter:  filter,
+		},
+	)
+	if err != nil {
+		panic(falcon.ErrorExplain(err))
+	}
+	payload := res.GetPayload()
+	if len(payload.Errors) != 0 {
+		fmt.Println(payload.Errors)
+		panic("Errors from the server")
+
+	}
+	return payload.Resources
+}
+
+func getValidOsNames(client *client.CrowdStrikeAPISpecification) []string {
+	sensors := getSensors(client, "")
+	type void struct{}
+	osNames := make(map[string]void)
+	for _, sensor := range sensors {
+		osNames[*sensor.Os] = void{}
+	}
+	list := []string{}
+	for k := range osNames {
+		list = append(list, k)
+	}
+	sort.Strings(list)
+	return list
+}
+
+func getValidOsVersions(client *client.CrowdStrikeAPISpecification, osName string) []string {
+	sensors := getSensors(client, osName)
+	type void struct{}
+	osVersions := make(map[string]void)
+	for _, sensor := range sensors {
+		osVersions[*sensor.OsVersion] = void{}
+	}
+	list := []string{}
+	for k := range osVersions {
+		list = append(list, k)
+	}
+	sort.Strings(list)
+	return list
+}

--- a/falcon/api_error.go
+++ b/falcon/api_error.go
@@ -1,0 +1,54 @@
+package falcon
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ErrorExplain extracts as much information from the error object as possible and returns as human readable string. This is useful for developers as gofalcon/falcon/client library is swagger generated and various error classes do not adhere to a common interface.
+func ErrorExplain(apiError error) string {
+	explained := tryErrorExplain(apiError)
+	if explained != "" {
+		return explained
+	}
+	return fmt.Sprintf("%#v", apiError)
+}
+
+// Common interface for *Payload structures in the gofalcon/falcon/client library.
+type CommonPayload interface {
+	MarshalBinary() ([]byte, error)
+}
+
+// ErrorExtractPayload pops out a .Payload member from the API Error (if included).
+func ErrorExtractPayload(apiError error) CommonPayload {
+	errorValue := reflect.ValueOf(apiError)
+	if errorValue.Kind() != reflect.Interface && errorValue.Kind() != reflect.Ptr {
+		// Not ours error
+		return nil
+	}
+	errorStruct := errorValue.Elem()
+	payloadValue := errorStruct.FieldByName("Payload")
+	if !payloadValue.CanInterface() {
+		// This error struct does not have 'Payload' member
+		return nil
+	}
+	payload := payloadValue.Interface()
+	casted, ok := payload.(CommonPayload)
+	if !ok {
+		// Cannot be casted
+		return nil
+	}
+	return casted
+}
+
+func tryErrorExplain(apiError error) string {
+	payload := ErrorExtractPayload(apiError)
+	if payload == nil {
+		return ""
+	}
+	bytes, err := payload.MarshalBinary()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%v\n[BODY %s]", apiError, string(bytes))
+}

--- a/falcon/client/sensor_download/download_sensor_installer_by_id_responses.go
+++ b/falcon/client/sensor_download/download_sensor_installer_by_id_responses.go
@@ -20,13 +20,14 @@ import (
 // DownloadSensorInstallerByIDReader is a Reader for the DownloadSensorInstallerByID structure.
 type DownloadSensorInstallerByIDReader struct {
 	formats strfmt.Registry
+	writer  io.Writer
 }
 
 // ReadResponse reads a server response into the received o.
 func (o *DownloadSensorInstallerByIDReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 	case 200:
-		result := NewDownloadSensorInstallerByIDOK()
+		result := NewDownloadSensorInstallerByIDOK(o.writer)
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -56,7 +57,7 @@ func (o *DownloadSensorInstallerByIDReader) ReadResponse(response runtime.Client
 		}
 		return nil, result
 	default:
-		result := NewDownloadSensorInstallerByIDDefault(response.Code())
+		result := NewDownloadSensorInstallerByIDDefault(response.Code(), o.writer)
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -68,8 +69,10 @@ func (o *DownloadSensorInstallerByIDReader) ReadResponse(response runtime.Client
 }
 
 // NewDownloadSensorInstallerByIDOK creates a DownloadSensorInstallerByIDOK with default headers values
-func NewDownloadSensorInstallerByIDOK() *DownloadSensorInstallerByIDOK {
-	return &DownloadSensorInstallerByIDOK{}
+func NewDownloadSensorInstallerByIDOK(writer io.Writer) *DownloadSensorInstallerByIDOK {
+	return &DownloadSensorInstallerByIDOK{
+		Payload: writer,
+	}
 }
 
 /*DownloadSensorInstallerByIDOK handles this case with default header values.
@@ -84,14 +87,14 @@ type DownloadSensorInstallerByIDOK struct {
 	 */
 	XRateLimitRemaining int64
 
-	Payload models.DomainDownloadItem
+	Payload io.Writer
 }
 
 func (o *DownloadSensorInstallerByIDOK) Error() string {
 	return fmt.Sprintf("[GET /sensors/entities/download-installer/v1][%d] downloadSensorInstallerByIdOK  %+v", 200, o.Payload)
 }
 
-func (o *DownloadSensorInstallerByIDOK) GetPayload() models.DomainDownloadItem {
+func (o *DownloadSensorInstallerByIDOK) GetPayload() io.Writer {
 	return o.Payload
 }
 
@@ -112,7 +115,7 @@ func (o *DownloadSensorInstallerByIDOK) readResponse(response runtime.ClientResp
 	o.XRateLimitRemaining = xRateLimitRemaining
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -346,9 +349,10 @@ func (o *DownloadSensorInstallerByIDTooManyRequests) readResponse(response runti
 }
 
 // NewDownloadSensorInstallerByIDDefault creates a DownloadSensorInstallerByIDDefault with default headers values
-func NewDownloadSensorInstallerByIDDefault(code int) *DownloadSensorInstallerByIDDefault {
+func NewDownloadSensorInstallerByIDDefault(code int, writer io.Writer) *DownloadSensorInstallerByIDDefault {
 	return &DownloadSensorInstallerByIDDefault{
 		_statusCode: code,
+		Payload:     writer,
 	}
 }
 
@@ -359,7 +363,7 @@ OK
 type DownloadSensorInstallerByIDDefault struct {
 	_statusCode int
 
-	Payload models.DomainDownloadItem
+	Payload io.Writer
 }
 
 // Code gets the status code for the download sensor installer by Id default response
@@ -371,14 +375,14 @@ func (o *DownloadSensorInstallerByIDDefault) Error() string {
 	return fmt.Sprintf("[GET /sensors/entities/download-installer/v1][%d] DownloadSensorInstallerById default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *DownloadSensorInstallerByIDDefault) GetPayload() models.DomainDownloadItem {
+func (o *DownloadSensorInstallerByIDDefault) GetPayload() io.Writer {
 	return o.Payload
 }
 
 func (o *DownloadSensorInstallerByIDDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/falcon/client/sensor_download/sensor_download_client.go
+++ b/falcon/client/sensor_download/sensor_download_client.go
@@ -6,6 +6,8 @@ package sensor_download
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"io"
+
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 )
@@ -25,7 +27,7 @@ type Client struct {
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DownloadSensorInstallerByID(params *DownloadSensorInstallerByIDParams) (*DownloadSensorInstallerByIDOK, error)
+	DownloadSensorInstallerByID(params *DownloadSensorInstallerByIDParams, writer io.Writer) (*DownloadSensorInstallerByIDOK, error)
 
 	GetCombinedSensorInstallersByQuery(params *GetCombinedSensorInstallersByQueryParams) (*GetCombinedSensorInstallersByQueryOK, error)
 
@@ -41,7 +43,7 @@ type ClientService interface {
 /*
   DownloadSensorInstallerByID downloads sensor installer by s h a256 ID
 */
-func (a *Client) DownloadSensorInstallerByID(params *DownloadSensorInstallerByIDParams) (*DownloadSensorInstallerByIDOK, error) {
+func (a *Client) DownloadSensorInstallerByID(params *DownloadSensorInstallerByIDParams, writer io.Writer) (*DownloadSensorInstallerByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDownloadSensorInstallerByIDParams()
@@ -55,7 +57,7 @@ func (a *Client) DownloadSensorInstallerByID(params *DownloadSensorInstallerByID
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
-		Reader:             &DownloadSensorInstallerByIDReader{formats: a.formats},
+		Reader:             &DownloadSensorInstallerByIDReader{formats: a.formats, writer: writer},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
 	})


### PR DESCRIPTION
Providing more evolved example of use of `gofalcon`. This example can be used as a stand-alone command-line tool to download the latest falcon-sensor locally.

Also, actually fixing the library to be able to download the sensor. 🤦 
