### PR TITLE
Provide debug option to the API Runtime

### DIFF
--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -16,6 +16,7 @@ func NewClient(ac *ApiConfig) (*client.CrowdStrikeAPISpecification, error) {
 	authenticatedClient := config.Client(ac.Context)
 	customTransport := httptransport.NewWithClient(
 		ac.Host(), ac.BasePath(), []string{}, authenticatedClient)
+	customTransport.Debug = ac.Debug
 
 	return client.New(customTransport, strfmt.Default), nil
 }

--- a/falcon/api_config.go
+++ b/falcon/api_config.go
@@ -13,6 +13,8 @@ type ApiConfig struct {
 	Context          context.Context
 	HostOverride     string
 	BasePathOverride string
+	// Debug all http traffic going through the API Runtime
+	Debug bool
 }
 
 func (ac *ApiConfig) Host() string {


### PR DESCRIPTION
When set, debug option allows developers to intercept all the http traffic going
through the API runtime. Following is a show-case output that may be produced:

```
GET /incidents/combined/crowdscores/v1?sort=timestamp.desc HTTP/1.1
Host: api.crowdstrike.com
User-Agent: Go-http-client/1.1
Accept: application/json
Accept-Encoding: gzip

HTTP/2.0 200 OK
Content-Type: application/json
Date: Sat, 30 Jan 2021 22:06:04 GMT
X-Cs-Region: us-1
X-Ratelimit-Limit: 6000
X-Ratelimit-Remaining: 5998

{
 "meta": {
  "query_time": 0.011722403,
  "pagination": {
   "offset": 0,
   "limit": 100,
   "total": 12969
  },
  "powered_by": "incident-api",
  "trace_id": "71bc2e44-4f89-46fd-9841-394e48065b9d"
 },
....
```