### PR TITLE
segfault: do not call CanInterface() on Zero reflect.Value

### DIFF
--- a/falcon/api_error.go
+++ b/falcon/api_error.go
@@ -28,6 +28,9 @@ func ErrorExtractPayload(apiError error) CommonPayload {
 	}
 	errorStruct := errorValue.Elem()
 	payloadValue := errorStruct.FieldByName("Payload")
+	if !payloadValue.IsValid() {
+		return nil
+	}
 	if !payloadValue.CanInterface() {
 		// This error struct does not have 'Payload' member
 		return nil


### PR DESCRIPTION
Addressing:
```
$ go run ./examples/falcon_sensor_download
panic: reflect: call of reflect.Value.CanInterface on zero Value

goroutine 1 [running]:
reflect.Value.CanInterface(...)
	/usr/local/Cellar/go/1.15.6/libexec/src/reflect/value.go:1005
gofalcon/falcon.ErrorExtractPayload(0x1c18ce0, 0xc00020a120, 0xc0003380d0, 0xc00022fb68)
	gofalcon/falcon/api_error.go:31 +0x239
gofalcon/falcon.tryErrorExplain(0x1c18ce0, 0xc00020a120, 0x1c18ce0, 0xc00020a120)
	gofalcon/falcon/api_error.go:45 +0x39
gofalcon/falcon.ErrorExplain(0x1c18ce0, 0xc00020a120, 0x0, 0x0)
	gofalcon/falcon/api_error.go:10 +0x39
main.getSensors(0xc00016ea00, 0x0, 0x0, 0x1a24520, 0x1b10c00, 0x1b10cde)
	gofalcon/examples/falcon_sensor_download/main.go:117 +0x287
main.getValidOsNames(0xc00016ea00, 0xc00016ea00, 0x0, 0x0)
	gofalcon/examples/falcon_sensor_download/main.go:129 +0x4b
main.main()
	gofalcon/examples/falcon_sensor_download/main.go:48 +0x714
exit status 2
```