### PR TITLE
Explain oauth2 errors better to the user

### DIFF
--- a/falcon/api_error.go
+++ b/falcon/api_error.go
@@ -2,11 +2,21 @@ package falcon
 
 import (
 	"fmt"
+	"net/url"
 	"reflect"
+
+	"golang.org/x/oauth2"
 )
 
 // ErrorExplain extracts as much information from the error object as possible and returns as human readable string. This is useful for developers as gofalcon/falcon/client library is swagger generated and various error classes do not adhere to a common interface.
 func ErrorExplain(apiError error) string {
+	if urlError, ok := apiError.(*url.Error); ok {
+	        cause := urlError.Unwrap()
+		if _, ok := cause.(*oauth2.RetrieveError); ok {
+			return apiError.Error()
+		}
+	}
+
 	explained := tryErrorExplain(apiError)
 	if explained != "" {
 		return explained


### PR DESCRIPTION
We can expect oauth errors to be fairly common at the end user when setting things up. We should do our best to explain the oauth errors.