### PR TITLE
Ease the usage of multi-cloud

### DIFF
--- a/examples/falcon_sensor_download/main.go
+++ b/examples/falcon_sensor_download/main.go
@@ -19,6 +19,7 @@ import (
 func main() {
 	clientId := flag.String("client-id", os.Getenv("FALCON_CLIENT_ID"), "Client ID for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_ID env)")
 	clientSecret := flag.String("client-secret", os.Getenv("FALCON_CLIENT_SECRET"), "Client Secret for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_SECRET)")
+	clientCloud := flag.String("cloud", os.Getenv("FALCON_CLOUD"), "Falcon cloud abbreviation (us-1, us-2, eu-1, us-gov-1)")
 	osName := flag.String("os-name", "", "Name of the operating system")
 	osVersion := flag.String("os-version", "", "Versin of the operating system")
 	all := flag.Bool("all", false, "Download all sensors")
@@ -37,6 +38,7 @@ Falcon Client Secret`)
 	client, err := falcon.NewClient(&falcon.ApiConfig{
 		ClientId:     *clientId,
 		ClientSecret: *clientSecret,
+		Cloud:        falcon.Cloud(*clientCloud),
 		Context:      context.Background(),
 	})
 	if err != nil {

--- a/examples/oauth_token/main.go
+++ b/examples/oauth_token/main.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"strings"
 
-	"github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/crowdstrike/gofalcon/falcon"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
 func main() {
 	clientId := flag.String("client-id", os.Getenv("FALCON_CLIENT_ID"), "Client ID for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_ID env)")
 	clientSecret := flag.String("client-secret", os.Getenv("FALCON_CLIENT_SECRET"), "Client Secret for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_SECRET)")
+	clientCloud := flag.String("cloud", os.Getenv("FALCON_CLOUD"), "Falcon cloud abbreviation (us-1, us-2, eu-1, us-gov-1)")
 	flag.Parse()
 
 	if *clientId == "" {
@@ -27,7 +28,7 @@ func main() {
 	config := clientcredentials.Config{
 		ClientID:     *clientId,
 		ClientSecret: *clientSecret,
-		TokenURL:     "https://" + client.DefaultHost + "/oauth2/token",
+		TokenURL:     "https://" + falcon.Cloud(*clientCloud).Host() + "/oauth2/token",
 	}
 	token, err := config.Token(context.Background())
 	if err != nil {

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	falconClientId := os.Getenv("FALCON_CLIENT_ID")
 	falconClientSecret := os.Getenv("FALCON_CLIENT_SECRET")
+	clientCloud := os.Getenv("FALCON_CLOUD")
 	if falconClientId == "" {
 		falconClientId = promptUser(`Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys.
 Falcon Client ID`)
@@ -26,6 +27,7 @@ Falcon Client Secret`)
 	client, err := falcon.NewClient(&falcon.ApiConfig{
 		ClientId:     falconClientId,
 		ClientSecret: falconClientSecret,
+		Cloud:        falcon.Cloud(clientCloud),
 		Context:      context.Background(),
 	})
 	if err != nil {

--- a/examples/stream_new_detections/main.go
+++ b/examples/stream_new_detections/main.go
@@ -20,6 +20,7 @@ import (
 func main() {
 	clientId := flag.String("client-id", os.Getenv("FALCON_CLIENT_ID"), "Client ID for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_ID env)")
 	clientSecret := flag.String("client-secret", os.Getenv("FALCON_CLIENT_SECRET"), "Client Secret for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_SECRET)")
+	clientCloud := flag.String("cloud", os.Getenv("FALCON_CLOUD"), "Falcon cloud abbreviation (us-1, us-2, eu-1, us-gov-1)")
 
 	flag.Parse()
 
@@ -35,6 +36,7 @@ Falcon Client Secret`)
 	client, err := falcon.NewClient(&falcon.ApiConfig{
 		ClientId:     *clientId,
 		ClientSecret: *clientSecret,
+		Cloud:        falcon.Cloud(*clientCloud),
 		Context:      context.Background(),
 	})
 	if err != nil {

--- a/falcon/api_config.go
+++ b/falcon/api_config.go
@@ -9,13 +9,15 @@ import (
 // ApiConfig object is used to initialise and configure API Client. Together with NewClient function, ApiConfig provides preferred way to initiate API communication.
 type ApiConfig struct {
 	// Client ID used for authentication with CrowdStrike Falcon platform. *required*
-	ClientId         string
+	ClientId string
 	// Client Secret used for authentication with CrowdStrike Falcon platform. *required*
-	ClientSecret     string
+	ClientSecret string
 	// This Context object will be used only when authenticating with the OAuth interface.
-	Context          context.Context
+	Context context.Context
+	// Cloud allows us to select Falcon Cloud to connect
+	Cloud CloudType
 	// HostOverride allows to override default host (default: api.crowdstrike.com)
-	HostOverride     string
+	HostOverride string
 	// BasePathOverride allows to override default base path (default: /)
 	BasePathOverride string
 	// Debug forces print out of all http traffic going through the API Runtime
@@ -23,10 +25,10 @@ type ApiConfig struct {
 }
 
 func (ac *ApiConfig) Host() string {
-	if ac.HostOverride == "" {
-		return client.DefaultHost
+	if ac.HostOverride != "" {
+		return ac.HostOverride
 	}
-	return ac.HostOverride
+	return ac.Cloud.Host()
 }
 
 func (ac *ApiConfig) BasePath() string {

--- a/falcon/cloud.go
+++ b/falcon/cloud.go
@@ -1,0 +1,54 @@
+package falcon
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CloudType int
+
+const (
+	CloudUs1 = iota
+	CloudUs2
+	CloudEu1
+	CloudUsGov1
+)
+
+// Cloud parses clould string (example: us-1, us-2, eu-1, us-gov-1, etc). If a string is not recognised CloudUs1 is returned.
+func Cloud(cloudString string) CloudType {
+	c, _ := CloudValidate(cloudString)
+	return c
+}
+
+// CloudValidate parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc.). Error is returned when string cannot be recognised
+func CloudValidate(cloudString string) (CloudType, error) {
+	trimmed := strings.TrimSpace(cloudString)
+	lower := strings.ToLower(trimmed)
+	switch lower {
+	case "us-1":
+		return CloudUs1, nil
+	case "us-2":
+		return CloudUs2, nil
+	case "eu-1":
+		return CloudEu1, nil
+	case "us-gov-1":
+		return CloudUsGov1, nil
+	}
+	return CloudUs1, fmt.Errorf("Unrecognised CrowdStrike Falcon Cloud: %s", lower)
+}
+
+// Host returns default hostname for given cloud.
+func (c CloudType) Host() string {
+	switch c {
+	default:
+		fallthrough
+	case CloudUs1:
+		return "api.crowdstrike.com"
+	case CloudUs2:
+		return "api.us-2.crowdstrike.com"
+	case CloudEu1:
+		return "api.eu-1.crowdstrike.com"
+	case CloudUsGov1:
+		return "api.laggar.gcw.crowdstrike.com"
+	}
+}


### PR DESCRIPTION
Adding `ApiConfig.Cloud` to ease usage of the library for multi-clouds. Note that `ApiConfig.HostOverride` could have been used instead.

Also adding command-line options to the examples.