### PR TITLE
Examples: Skip Falcon SIEM Connector when downloading sensor

### DIFF
--- a/examples/falcon_sensor_download/main.go
+++ b/examples/falcon_sensor_download/main.go
@@ -140,7 +140,15 @@ func getSensors(client *client.CrowdStrikeAPISpecification, osName string) []*mo
 		panic("Errors from the server")
 
 	}
-	return payload.Resources
+	k := 0
+	for _, sensor := range payload.Resources {
+		if strings.Contains(*sensor.Description, "Falcon SIEM Connector") {
+			continue
+		}
+		payload.Resources[k] = sensor
+		k++
+	}
+	return payload.Resources[:k]
 }
 
 func getValidOsNames(client *client.CrowdStrikeAPISpecification) []string {


### PR DESCRIPTION
Addressing new extra items appearing on the API.
```
{
    "description": "Falcon SIEM Connector for CentOS/RHEL",
    "file_size": 4928684,
    "file_type": "rpm",
    "name": "cs.falconhoseclient-2.5.4+005-1.el7.x86_64.rpm",
    "os": "",
    "os_version": "",
    "platform": "",
    "release_date": "2021-03-25T17:16:59.959Z",
    "sha256": "a97fb20d2031a20ff859175d5a8b516f28f920e0a18a5f02b651cbc8b7d21f93",
    "version": "2.5.4"
}
{
    "description": "Falcon SIEM Connector for Ubuntu",
    "file_size": 9406046,
    "file_type": "deb",
    "name": "crowdstrike-cs-falconhoseclient_2.5.4+005-siem-release-2.5.4_amd64.deb",
    "os": "",
    "os_version": "",
    "platform": "",
    "release_date": "2021-03-25T17:15:27.430Z",
    "sha256": "2ab3416a4df879d771a1691ce4f8d2328140e4bc63bd2c27bf6f24a10fccc065",
    "version": "2.5.4"
}
```