### PR TITLE
Allow for ProcessId to be transferred over the wire as either Int or String

### DIFF
--- a/falcon/models/streaming_models/models.go
+++ b/falcon/models/streaming_models/models.go
@@ -37,7 +37,7 @@ type Event struct {
 	FilePath                      *string                  `json:"FilePath,omitempty"`
 	ProcessStartTime              *uint64                  `json:"ProcessStartTime,omitempty"`
 	ProcessEndTime                *uint64                  `json:"ProcessEndTime,omitempty"`
-	ProcessId                     *uint64                  `json:"ProcessId,omitempty"`
+	ProcessId                     *IntOrString             `json:"ProcessId,omitempty"`
 	UserName                      *string                  `json:"UserName,omitempty"`
 	DetectName                    *string                  `json:"DetectName,omitempty"`
 	CommandLine                   *string                  `json:"CommandLine,omitempty"`
@@ -55,11 +55,11 @@ type Event struct {
 	DocumentsAccessed             []DocumentsAccessed      `json:"DocumentsAccessed,omitempty"`
 	Commands                      []string                 `json:"Commands,omitempty"`
 
-	ParentProcesssId         *uint64 `json:"ParentProcessId,omitempty"`
-	ParentCommandLine        *string `json:"ParentCommandLine,omitempty"`
-	ParentImageFileName      *string `json:"ParentImageFileName,omitempty"`
-	GrandparentCommandLine   *string `json:"GrandparentCommandLine,omitempty"`
-	GrandparentImageFileName *string `json:"GrandparentImageFilename,omitempty"`
+	ParentProcesssId         *IntOrString `json:"ParentProcessId,omitempty"`
+	ParentCommandLine        *string      `json:"ParentCommandLine,omitempty"`
+	ParentImageFileName      *string      `json:"ParentImageFileName,omitempty"`
+	GrandparentCommandLine   *string      `json:"GrandparentCommandLine,omitempty"`
+	GrandparentImageFileName *string      `json:"GrandparentImageFilename,omitempty"`
 
 	NetworkAccesses   []NetworkAccess  `json:"NetworkAccesses,omitempty"`
 	Severity          *float64         `json:"Severity,omitempty"`

--- a/falcon/models/streaming_models/utils.go
+++ b/falcon/models/streaming_models/utils.go
@@ -1,0 +1,32 @@
+package streaming_models
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type IntOrString uint64
+
+func (st *IntOrString) UnmarshalJSON(b []byte) error {
+	var item interface{}
+	if err := json.Unmarshal(b, &item); err != nil {
+		return err
+	}
+
+	switch v := item.(type) {
+	case uint64:
+		*st = IntOrString(v)
+	case float64:
+		*st = IntOrString(uint64(v))
+	case string:
+		i, err := strconv.ParseUint(v, 10, 0)
+		if err != nil {
+			return err
+		}
+		*st = IntOrString(i)
+	default:
+		return fmt.Errorf("Not implemented: Cannot parse: %v (type %T) to IntOrString", item, item)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #83.