### PR TITLE
Allow blank string to be parsed from Streaming API

### DIFF
--- a/falcon/models/streaming_models/utils.go
+++ b/falcon/models/streaming_models/utils.go
@@ -20,9 +20,13 @@ func (st *IntOrString) UnmarshalJSON(b []byte) error {
 	case float64:
 		*st = IntOrString(uint64(v))
 	case string:
-		i, err := strconv.ParseUint(v, 10, 0)
-		if err != nil {
-			return err
+		i := uint64(0)
+		if v != "" {
+			var err error
+			i, err = strconv.ParseUint(v, 10, 0)
+			if err != nil {
+				return err
+			}
 		}
 		*st = IntOrString(i)
 	default:


### PR DESCRIPTION
Addressing:
```
strconv.ParseUint: parsing "": invalid syntax
ERROR: strconv.ParseUint: parsing "": invalid syntax
```

Relates: #83