### PR TITLE
Provide unified way to check for application errors

### DIFF
--- a/examples/falcon_cleanup_pods/main.go
+++ b/examples/falcon_cleanup_pods/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -76,20 +75,7 @@ func hideHost(client *client.CrowdStrikeAPISpecification, id string) error {
 	if err != nil {
 		return err
 	}
-	return checkPayloadErrors(response.Payload.Errors)
-}
-
-// checkPayloadErrors converts MsaAPIError to golang error
-func checkPayloadErrors(payloadErrors []*models.MsaAPIError) error {
-	if len(payloadErrors) == 0 {
-		return nil
-	}
-	var sb strings.Builder
-
-	for _, payloadError := range payloadErrors {
-		sb.WriteString("API Error " + payloadError.ID + ": " + *payloadError.Message)
-	}
-	return errors.New(sb.String())
+	return falcon.AssertNoError(response.Payload.Errors)
 }
 
 func getHostDetails(client *client.CrowdStrikeAPISpecification, hostId string) *models.DomainDeviceSwagger {
@@ -100,9 +86,8 @@ func getHostDetails(client *client.CrowdStrikeAPISpecification, hostId string) *
 	if err != nil {
 		panic(falcon.ErrorExplain(err))
 	}
-	for _, e := range response.Payload.Errors {
-		fmt.Println(e)
-		panic("Error received when querying Host Details API")
+	if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+		panic(err)
 	}
 
 	return response.Payload.Resources[0]
@@ -125,9 +110,8 @@ func getInactivePodIds(client *client.CrowdStrikeAPISpecification, inactiveDays 
 		if err != nil {
 			panic(falcon.ErrorExplain(err))
 		}
-		for _, e := range response.Payload.Errors {
-			fmt.Println(e)
-			panic("Error received when querying Hosts API")
+		if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+			panic(err)
 		}
 		podCount := *response.Payload.Meta.Pagination.Total
 		fmt.Printf("Found %d pods that have been inactive\n", podCount)
@@ -143,9 +127,8 @@ func getInactivePodIds(client *client.CrowdStrikeAPISpecification, inactiveDays 
 			if err != nil {
 				panic(falcon.ErrorExplain(err))
 			}
-			for _, e := range response.Payload.Errors {
-				fmt.Println(e)
-				panic("Error received when querying Hosts API")
+			if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+				panic(err)
 			}
 
 			hosts := response.Payload.Resources

--- a/examples/falcon_event_stream/main.go
+++ b/examples/falcon_event_stream/main.go
@@ -52,8 +52,8 @@ Falcon Client Secret`)
 	if err != nil {
 		panic(falcon.ErrorExplain(err))
 	}
-	for _, e := range response.Payload.Errors {
-		fmt.Println(e)
+	if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+		panic(err)
 	}
 
 	availableStreams := response.Payload.Resources

--- a/examples/falcon_host_details/main.go
+++ b/examples/falcon_host_details/main.go
@@ -76,9 +76,8 @@ func getHostsDetails(client *client.CrowdStrikeAPISpecification, hostIds []strin
 	if err != nil {
 		panic(falcon.ErrorExplain(err))
 	}
-	for _, e := range response.Payload.Errors {
-		fmt.Println(e)
-		panic("Error received when querying Host Details API")
+	if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+		panic(err)
 	}
 
 	return response.Payload.Resources
@@ -98,9 +97,8 @@ func getHostIds(client *client.CrowdStrikeAPISpecification) <-chan []string {
 			if err != nil {
 				panic(falcon.ErrorExplain(err))
 			}
-			for _, e := range response.Payload.Errors {
-				fmt.Println(e)
-				panic("Error received when querying Hosts API")
+			if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+				panic(err)
 			}
 
 			hosts := response.Payload.Resources

--- a/examples/falcon_sensor_download/main.go
+++ b/examples/falcon_sensor_download/main.go
@@ -137,11 +137,10 @@ func getSensors(client *client.CrowdStrikeAPISpecification, osName string) []*mo
 		panic(falcon.ErrorExplain(err))
 	}
 	payload := res.GetPayload()
-	if len(payload.Errors) != 0 {
-		fmt.Println(payload.Errors)
-		panic("Errors from the server")
-
+	if err = falcon.AssertNoError(payload.Errors); err != nil {
+		panic(err)
 	}
+
 	k := 0
 	for _, sensor := range payload.Resources {
 		if strings.Contains(*sensor.Description, "Falcon SIEM Connector") {
@@ -220,6 +219,10 @@ func oneSensorPerOsVersion(client *client.CrowdStrikeAPISpecification) <-chan *m
 	if err != nil {
 		panic(falcon.ErrorExplain(err))
 	}
+	if err = falcon.AssertNoError(sensors.Payload.Errors); err != nil {
+		panic(err)
+	}
+
 	go func() {
 		uniq := map[string]map[string]void{}
 		for _, s := range sensors.GetPayload().Resources {

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -43,6 +43,9 @@ Falcon Client Secret`)
 		panic(err)
 	}
 	payload := res.GetPayload()
+	if err = falcon.AssertNoError(payload.Errors); err != nil {
+		panic(err)
+	}
 	fmt.Printf("As of %s your CrowdScore is %d.\n",
 		payload.Resources[0].Timestamp.String(), *payload.Resources[0].Score)
 }

--- a/examples/stream_new_detections/main.go
+++ b/examples/stream_new_detections/main.go
@@ -72,8 +72,8 @@ func streamDetections(c *client.CrowdStrikeAPISpecification) <-chan *models.Doma
 			if err != nil {
 				panic(falcon.ErrorExplain(err))
 			}
-			for _, e := range response.Payload.Errors {
-				fmt.Println(e)
+			if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+				panic(err)
 			}
 			unseen := []string{}
 			for _, d := range response.Payload.Resources {
@@ -91,9 +91,10 @@ func streamDetections(c *client.CrowdStrikeAPISpecification) <-chan *models.Doma
 				if err != nil {
 					panic(falcon.ErrorExplain(err))
 				}
-				for _, e := range response.Payload.Errors {
-					fmt.Println(e)
+				if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+					panic(err)
 				}
+
 				res := response.Payload.Resources
 
 				sort.SliceStable(res, func(i, j int) bool {

--- a/falcon/api_error.go
+++ b/falcon/api_error.go
@@ -1,12 +1,30 @@
 package falcon
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
+	"strings"
 
+	"github.com/crowdstrike/gofalcon/falcon/models"
 	"golang.org/x/oauth2"
 )
+
+// AssertNoError converts MsaAPIError to golang errors
+// Falcon API oftentimes returns payload structure that may include application errors within MsaAPIError list.
+// For the users of the API it is often times desirable to convert the application errors from CrowdStrike platform to golang native errors to inform application flow.
+func AssertNoError(payloadErrors []*models.MsaAPIError) error {
+	if len(payloadErrors) == 0 {
+		return nil
+	}
+	var sb strings.Builder
+
+	for _, payloadError := range payloadErrors {
+		sb.WriteString("API Error " + payloadError.ID + ": " + *payloadError.Message)
+	}
+	return errors.New(sb.String())
+}
 
 // ErrorExplain extracts as much information from the error object as possible and returns as human readable string. This is useful for developers as gofalcon/falcon/client library is swagger generated and various error classes do not adhere to a common interface.
 func ErrorExplain(apiError error) string {


### PR DESCRIPTION
`AssertNoError` converts `MsaAPIError` to golang `error`. Falcon API oftentimes returns payload structure that may include application errors within `MsaAPIError` list. For the users of the API it is often times desirable to convert the application errors from CrowdStrike platform to golang native errors to inform application flow.