### PR TITLE
Ignore warning of the latest gosec tool

### DIFF
--- a/examples/falcon_sensor_download/main.go
+++ b/examples/falcon_sensor_download/main.go
@@ -101,7 +101,9 @@ func download(client *client.CrowdStrikeAPISpecification, sensor *models.DomainS
 	if err != nil {
 		panic(err)
 	}
+	/* #nosec */
 	defer func() {
+		// (ignore possibly false positive https://github.com/securego/gosec/issues/714)
 		if err := file.Close(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
 		}


### PR DESCRIPTION
This looks like a possible false positives, at least until we learn more at https://github.com/securego/gosec/issues/714

Addressing:
```
[/github/workspace/examples/falcon_sensor_download/main.go:104-108] - G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
    103: 	}
  > 104: 	defer func() {
  > 105: 		if err := file.Close(); err != nil {
  > 106: 			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
  > 107: 		}
  > 108: 	}()
    109:
```