### PR TITLE
Make warning message more readable for bigger deployments

### DIFF
--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -48,7 +48,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Add("User-Agent", userAgent)
 
 	if rt.LastRateLimitDigits == 1 || rt.LastRateLimitDigits == 2 {
-		log.Debug("Approaching API rate limits. Waiting 500 millisecond.")
+		log.Debug("Approaching CrowdStrike API rate limits. Waiting 500 millisecond.")
 		time.Sleep(500 * time.Millisecond)
 	}
 	response, err := rt.T.RoundTrip(req)


### PR DESCRIPTION
In cases, when gofalcon is part of greater integration, it may not be obvious that the log message is coming out of gofalcon.