### PR TITLE
Provide explicit name for Falcon Cloud Region autodiscovery

### DIFF
--- a/falcon/cloud.go
+++ b/falcon/cloud.go
@@ -33,6 +33,8 @@ func CloudValidate(cloudString string) (CloudType, error) {
 	lower := strings.ToLower(trimmed)
 	switch lower {
 	case "":
+		fallthrough
+	case "autodiscover":
 		return CloudAutoDiscover, nil
 	case "us-1":
 		return CloudUs1, nil
@@ -65,7 +67,7 @@ func (c CloudType) Host() string {
 func (c CloudType) String() string {
 	switch c {
 	case CloudAutoDiscover:
-		return ""
+		return "autodiscover"
 	case CloudUs1:
 		return "us-1"
 	case CloudUs2:


### PR DESCRIPTION
This will allow us to include the following excerpt to documentation:

    FALCON_CLOUD="autodiscover"

Users seeing this, will know the option exists, while at the same time they will
be able to get away with not setting it. Sharing the information about the
option existence is beneficial to certain class of users, who like to be
particularly explicit about stuff.