### PR TITLE
CI: Drop testing on go1.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
At this point, if the 1.14 CI was going to fail, we would drop it
anyway.