### PR TITLE
Refactored example falcon_host_details to use devices-scroll API endpoint

### DIFF
--- a/examples/falcon_host_details/README.md
+++ b/examples/falcon_host_details/README.md
@@ -1,6 +1,6 @@
 # Falcon Host Details
 
-Stand-alone tool that uses Host API to query all the host details and output JSON to the stdout. This tool can be used together with JSON parsing tools like `jq` in order to build reports of your liking.
+Stand-alone tool that uses Host devices scroll API to query all the host details and output JSON to the stdout. This tool can be used together with JSON parsing tools like `jq` in order to build reports of your liking.
 
 ## Installation
 


### PR DESCRIPTION
This refactor allows overcoming the default limit of 10,000 devices implemented on the /devices/v1 endpoint.