### PR TITLE
examples: Update limits on V2 Host Details API

### DIFF
--- a/examples/falcon_cleanup_hosts/main.go
+++ b/examples/falcon_cleanup_hosts/main.go
@@ -219,8 +219,8 @@ func getAllHostDetails(client *client.CrowdStrikeAPISpecification, filter *strin
 }
 
 func getHostsDetails(client *client.CrowdStrikeAPISpecification, hostIds []string) []*models.DeviceapiDeviceSwagger {
-	response, err := client.Hosts.GetDeviceDetailsV2(&hosts.GetDeviceDetailsV2Params{
-		Ids:     hostIds,
+	response, err := client.Hosts.PostDeviceDetailsV2(&hosts.PostDeviceDetailsV2Params{
+		Body:    &models.MsaIdsRequest{Ids: hostIds},
 		Context: context.Background(),
 	})
 	if err != nil {
@@ -237,7 +237,7 @@ func getHostIds(client *client.CrowdStrikeAPISpecification, filter *string) <-ch
 	hostIds := make(chan []string)
 
 	go func() {
-		limit := int64(100)
+		limit := int64(5000)
 		for offset := int64(0); ; {
 			response, err := client.Hosts.QueryDevicesByFilter(&hosts.QueryDevicesByFilterParams{
 				Limit:   &limit,

--- a/examples/falcon_cleanup_hosts/main.go
+++ b/examples/falcon_cleanup_hosts/main.go
@@ -237,7 +237,7 @@ func getHostIds(client *client.CrowdStrikeAPISpecification, filter *string) <-ch
 	hostIds := make(chan []string)
 
 	go func() {
-		limit := int64(500)
+		limit := int64(100)
 		for offset := int64(0); ; {
 			response, err := client.Hosts.QueryDevicesByFilter(&hosts.QueryDevicesByFilterParams{
 				Limit:   &limit,

--- a/examples/falcon_host_details/main.go
+++ b/examples/falcon_host_details/main.go
@@ -70,8 +70,8 @@ Falcon Client Secret`)
 }
 
 func getHostsDetails(client *client.CrowdStrikeAPISpecification, hostIds []string) []*models.DeviceapiDeviceSwagger {
-	response, err := client.Hosts.GetDeviceDetailsV2(&hosts.GetDeviceDetailsV2Params{
-		Ids:     hostIds,
+	response, err := client.Hosts.PostDeviceDetailsV2(&hosts.PostDeviceDetailsV2Params{
+		Body:    &models.MsaIdsRequest{Ids: hostIds},
 		Context: context.Background(),
 	})
 	if err != nil {
@@ -88,7 +88,7 @@ func getHostIds(client *client.CrowdStrikeAPISpecification, filter *string) <-ch
 	hostIds := make(chan []string)
 
 	go func() {
-		limit := int64(100)
+		limit := int64(5000)
 		for offset := ""; ; {
 			response, err := client.Hosts.QueryDevicesByFilterScroll(&hosts.QueryDevicesByFilterScrollParams{
 				Context: context.Background(),

--- a/examples/falcon_host_details/main.go
+++ b/examples/falcon_host_details/main.go
@@ -88,7 +88,7 @@ func getHostIds(client *client.CrowdStrikeAPISpecification, filter *string) <-ch
 	hostIds := make(chan []string)
 
 	go func() {
-		limit := int64(500)
+		limit := int64(100)
 		for offset := ""; ; {
 			response, err := client.Hosts.QueryDevicesByFilterScroll(&hosts.QueryDevicesByFilterScrollParams{
 				Context: context.Background(),


### PR DESCRIPTION
The new /devices/entities/devices/v2 API endpoint has a limit of 100
device IDs (when called with GET rather than POST). However, the
examples still used the v1 API's larger limit of 500.