### PR TITLE
Device API V1 to V2 Migration

### DIFF
--- a/falcon/client/hosts/get_device_details_responses.go
+++ b/falcon/client/hosts/get_device_details_responses.go
@@ -108,11 +108,11 @@ func (o *GetDeviceDetailsOK) IsCode(code int) bool {
 }
 
 func (o *GetDeviceDetailsOK) Error() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] getDeviceDetailsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] getDeviceDetailsOK  %+v", 200, o.Payload)
 }
 
 func (o *GetDeviceDetailsOK) String() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] getDeviceDetailsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] getDeviceDetailsOK  %+v", 200, o.Payload)
 }
 
 func (o *GetDeviceDetailsOK) GetPayload() *models.DomainDeviceDetailsResponseSwagger {
@@ -213,11 +213,11 @@ func (o *GetDeviceDetailsForbidden) IsCode(code int) bool {
 }
 
 func (o *GetDeviceDetailsForbidden) Error() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] getDeviceDetailsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] getDeviceDetailsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetDeviceDetailsForbidden) String() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] getDeviceDetailsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] getDeviceDetailsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetDeviceDetailsForbidden) GetPayload() *models.MsaReplyMetaOnly {
@@ -322,11 +322,11 @@ func (o *GetDeviceDetailsTooManyRequests) IsCode(code int) bool {
 }
 
 func (o *GetDeviceDetailsTooManyRequests) Error() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] getDeviceDetailsTooManyRequests  %+v", 429, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] getDeviceDetailsTooManyRequests  %+v", 429, o.Payload)
 }
 
 func (o *GetDeviceDetailsTooManyRequests) String() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] getDeviceDetailsTooManyRequests  %+v", 429, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] getDeviceDetailsTooManyRequests  %+v", 429, o.Payload)
 }
 
 func (o *GetDeviceDetailsTooManyRequests) GetPayload() *models.MsaReplyMetaOnly {
@@ -434,11 +434,11 @@ func (o *GetDeviceDetailsDefault) IsCode(code int) bool {
 }
 
 func (o *GetDeviceDetailsDefault) Error() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] GetDeviceDetails default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] GetDeviceDetails default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *GetDeviceDetailsDefault) String() string {
-	return fmt.Sprintf("[GET /devices/entities/devices/v1][%d] GetDeviceDetails default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /devices/entities/devices//v2][%d] GetDeviceDetails default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *GetDeviceDetailsDefault) GetPayload() *models.DomainDeviceDetailsResponseSwagger {

--- a/falcon/client/hosts/hosts_client.go
+++ b/falcon/client/hosts/hosts_client.go
@@ -58,7 +58,7 @@ type ClientService interface {
 }
 
 /*
-GetDeviceDetails deprecateds please use new g e t or p o s t devices entities devices v2 endpoints this endpoint will be removed on or sometime after february 9 2023 get details on one or more hosts by providing agent i ds a ID you can get a host s agent i ds a i ds from the devices queries devices v1 endpoint the falcon console or the streaming API
+GetDeviceDetails deprecateds please use new methods get device details v2 or post device details v2 this method now redirects to get device details v2 the original API endpoint will be removed on or sometime after february 9 2023
 */
 func (a *Client) GetDeviceDetails(params *GetDeviceDetailsParams, opts ...ClientOption) (*GetDeviceDetailsOK, error) {
 	// TODO: Validate the params before sending
@@ -68,7 +68,7 @@ func (a *Client) GetDeviceDetails(params *GetDeviceDetailsParams, opts ...Client
 	op := &runtime.ClientOperation{
 		ID:                 "GetDeviceDetails",
 		Method:             "GET",
-		PathPattern:        "/devices/entities/devices/v1",
+		PathPattern:        "/devices/entities/devices//v2",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"https"},

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -20,10 +20,18 @@
   # Rename msaspec.MetaInfo to msa.MetaInfo. These are two names for the same type.
   | del(.definitions."msaspec.MetaInfo")
 
+
+  # Device v1 API has been deprecated since August 2022. And the end point will be removed at some point in the future.
+  | del(.paths."/devices/entities/devices/v1")
+  | .paths."/devices/entities/devices//v2".get = .paths."/devices/entities/devices/v2".get
+  | .paths."/devices/entities/devices//v2".get.operationId = "GetDeviceDetails"
+  | .paths."/devices/entities/devices//v2".get.deprecated = true
+  | .paths."/devices/entities/devices//v2".get.summary = "Deprecated: Please use new methods: GetDeviceDetailsV2 or	PostDeviceDetailsV2. This method now redirects to GetDeviceDetailsV2. The original API endpoint will be removed on or sometime after February 9, 2023."
+  | .paths."/devices/entities/devices//v2".get.responses."200".schema."$ref" = "#/definitions/domain.DeviceDetailsResponseSwagger"
+  | .paths."/devices/entities/devices//v2".get.responses.default.schema."$ref" = "#/definitions/domain.DeviceDetailsResponseSwagger"
+
   # A patch until DeviceDetails v1 gets removed
   | .definitions."domain.DeviceDetailsResponseSwagger" = .definitions."deviceapi.DeviceDetailsResponseSwagger"
-  | .paths."/devices/entities/devices/v1".get.responses."200".schema."$ref" = "#/definitions/domain.DeviceDetailsResponseSwagger"
-  | .paths."/devices/entities/devices/v1".get.responses.default.schema."$ref" = "#/definitions/domain.DeviceDetailsResponseSwagger"
   | .definitions."domain.DeviceSwagger" = .definitions."deviceapi.DeviceSwagger"
   | .definitions."domain.DeviceDetailsResponseSwagger".properties.resources.items."$ref" = "#/definitions/domain.DeviceSwagger"
 
@@ -40,4 +48,5 @@
   # Needed by rusty-falcon (stricter typing)
   | .definitions."deviceapi.DeviceDetailsResponseSwagger".properties.errors."x-nullable" = true
 
+  # IOA Rule Groups Combined API has incorrect swagger response object: list of ids instead of list of objects
   | .paths."/ioarules/queries/rule-groups-full/v1".get.responses."200" = .paths."/ioarules/entities/rule-groups/v1".get.responses."200"


### PR DESCRIPTION
This commit replaces calls to the v1 API transparently with calls of v2 API.

Users who are actively using method named

    GetDeviceDetails

will now call Device API v2. However, they should remember this method is deprecated and thus may disappear in future releases.