### PR TITLE
go 1.20 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.16.x]
+        go-version: [1.20.x]
 
     runs-on: ${{ matrix.os }}
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crowdstrike/gofalcon
 
-go 1.15
+go 1.17
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Add go 1.20 to the CI. Retire 1.16 from the CI. And bump required go version as we will soon have to drop support for go 1.16.