### PR TITLE
Add ability to decorate the HTTP transport for all API client requests.

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -46,3 +46,4 @@ macOS
 Zsh
 PowerShell
 SemVer
+TransportDecorator

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Gofalcon documentation is available on [pkg.go.dev](https://pkg.go.dev/github.co
 | [falcon_spotlight_vulnerabilities](examples/falcon_spotlight_vulnerabilities) | stand-alone tool that outputs inventory of vulnerabilities affecting your environment                                               |
 | [falcon_supported_kernels](examples/falcon_supported_kernels)                 | stand-alone tool that outputs short list recent Linux kernels supported by CrowdStrike Falcon for a given distribution              |
 | [falcon_zta](examples/falcon_zta)                                             | stand-alone tool that utilises Hosts and ZTA APIs and outputs ZTA findings for your environment                                     |
+| [customize_transport](examples/customize_transport)                           | use a falcon.TransportDecorator to modify all outgoing HTTP requests to the Falcon API |
 
 Gofalcon is an open source project, not a CrowdStrike product. As such, it carries
 no formal support, expressed or implied.

--- a/examples/customize_transport/README.md
+++ b/examples/customize_transport/README.md
@@ -1,0 +1,20 @@
+# Customize Transport
+
+This example builds on the falcon_host_details example to demonstrate the use of a `falcon.TransportDecorator` to customize HTTP client requests to the Falcon API for all calls.
+
+## Installation
+
+```
+go get github.com/crowdstrike/gofalcon/examples/customize_transport
+```
+
+## Exemplary Usage
+
+Get full details of all the hosts, with information about rate limits.
+
+```
+$ FALCON_CLIENT_ID="abc" FALCON_CLIENT_SECRET="XYZ" FALCON_CLOUD=us-1 \
+      FALCON_RATE_LIMIT_THRESHOLD="100" customize_transport
+```
+
+The Falcon API rate limit information provided by the `falcon.TransportDecorator` in this example will be the beginning out the output.

--- a/examples/customize_transport/main.go
+++ b/examples/customize_transport/main.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/crowdstrike/gofalcon/falcon"
+	"github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/crowdstrike/gofalcon/falcon/client/hosts"
+	"github.com/crowdstrike/gofalcon/falcon/models"
+	"github.com/crowdstrike/gofalcon/pkg/falcon_util"
+)
+
+func main() {
+	clientId := flag.String("client-id", os.Getenv("FALCON_CLIENT_ID"), "Client ID for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_ID env)")
+	clientSecret := flag.String("client-secret", os.Getenv("FALCON_CLIENT_SECRET"), "Client Secret for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_SECRET)")
+	memberCID := flag.String("member-cid", os.Getenv("FALCON_MEMBER_CID"), "Member CID for MSSP (for cases when OAuth2 authenticates multiple CIDs)")
+	clientCloud := flag.String("cloud", os.Getenv("FALCON_CLOUD"), "Falcon cloud abbreviation (us-1, us-2, eu-1, us-gov-1)")
+	filter := flag.String("filter", "", "Host search expression using Falcon Query Language (FQL)")
+	thresholdString := flag.String("rate-limit-threshold", os.Getenv("FALCON_RATE_LIMIT_THRESHOLD"), "Minimum remaining requests before taking further action (default taken from FALCON_RATE_LIMIT_THRESHOLD)")
+
+	flag.Parse()
+
+	if *clientId == "" {
+		*clientId = falcon_util.PromptUser(`Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys.
+Falcon Client ID`)
+	}
+	if *clientSecret == "" {
+		*clientSecret = falcon_util.PromptUser(`Missing FALCON_CLIENT_SECRET environment variable. Please provide your OAuth2 API Client Secret for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys.
+Falcon Client Secret`)
+	}
+	if *filter == "" {
+		filter = nil
+	}
+	if *thresholdString == "" {
+		*thresholdString = "100"
+	}
+
+	threshold, err := strconv.ParseInt(*thresholdString, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+
+	client, err := falcon.NewClient(&falcon.ApiConfig{
+		ClientId:           *clientId,
+		ClientSecret:       *clientSecret,
+		MemberCID:          *memberCID,
+		Cloud:              falcon.Cloud(*clientCloud),
+		Context:            context.Background(),
+		TransportDecorator: newRateLimitingInspectingTransportDecorator(threshold),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	empty := true
+	firstIteration := true
+	for hostIdBatch := range getHostIds(client, filter) {
+		if len(hostIdBatch) == 0 {
+			continue
+		}
+		hostDetailBatch := getHostsDetails(client, hostIdBatch)
+		for _, host := range hostDetailBatch {
+			json, err := falcon_util.PrettyJson(host)
+			if err != nil {
+				panic(err)
+			}
+			if !empty {
+				json = "," + json
+			} else {
+				empty = false
+			}
+			if firstIteration {
+				fmt.Println("[")
+				firstIteration = false
+			}
+			fmt.Println(json)
+		}
+	}
+	fmt.Println("]")
+}
+
+func getHostsDetails(client *client.CrowdStrikeAPISpecification, hostIds []string) []*models.DeviceapiDeviceSwagger {
+	response, err := client.Hosts.PostDeviceDetailsV2(&hosts.PostDeviceDetailsV2Params{
+		Body:    &models.MsaIdsRequest{Ids: hostIds},
+		Context: context.Background(),
+	})
+	if err != nil {
+		panic(falcon.ErrorExplain(err))
+	}
+	if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+		panic(err)
+	}
+
+	return response.Payload.Resources
+}
+
+func getHostIds(client *client.CrowdStrikeAPISpecification, filter *string) <-chan []string {
+	hostIds := make(chan []string)
+
+	go func() {
+		limit := int64(5000)
+		for offset := ""; ; {
+			response, err := client.Hosts.QueryDevicesByFilterScroll(&hosts.QueryDevicesByFilterScrollParams{
+				Context: context.Background(),
+				Limit:   &limit,
+				Offset:  &offset,
+				Filter:  filter,
+			})
+			if err != nil {
+				panic(falcon.ErrorExplain(err))
+			}
+			if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
+				panic(err)
+			}
+
+			hosts := response.Payload.Resources
+			if len(hosts) == 0 {
+				break
+			}
+
+			hostIds <- hosts
+
+			if *response.Payload.Meta.Pagination.Offset == "" || int64(len(hosts)) < limit {
+				break // no more next page indicates we are done
+			}
+
+			offset = *response.Payload.Meta.Pagination.Offset
+		}
+		close(hostIds)
+	}()
+	return hostIds
+}
+
+// rateLimitInspectingTransport provides information about the number of requests remaining in the ratelimit window.
+type rateLimitInspectingTransport struct {
+	wrapped   http.RoundTripper
+	threshold int64
+	remaining int64
+}
+
+// newRateLimitingInspectingTransportDecorator returns a falcon.TransportDecorator that
+// when invoked returns a configured rateLimitInspectingTransport around the given transport.
+func newRateLimitingInspectingTransportDecorator(threshold int64) func(http.RoundTripper) http.RoundTripper {
+	return func(wrapped http.RoundTripper) http.RoundTripper {
+		return &rateLimitInspectingTransport{wrapped: wrapped, threshold: threshold, remaining: -1}
+	}
+}
+
+// RoundTrip decorates the behavior of the wrapped transport with support for Falcon API rate limiting.
+func (t *rateLimitInspectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.remaining != -1 {
+		fmt.Printf("Remaining calls: %d. Threshold: %d.\n", t.remaining, t.threshold)
+		if t.remaining <= t.threshold {
+			fmt.Println("Remaining call threshold reached. Consider a delay and/or retry with backoff.")
+		}
+	}
+
+	response, err := t.wrapped.RoundTrip(req)
+	if response != nil {
+		remaining, err := strconv.ParseInt(response.Header.Get("X-Ratelimit-Remaining"), 10, 64)
+		if err == nil {
+			t.remaining = remaining
+		}
+	}
+
+	return response, err
+}

--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -46,6 +46,12 @@ func NewClient(ac *ApiConfig) (*client.CrowdStrikeAPISpecification, error) {
 		},
 		UserAgent: ac.UserAgent(),
 	}
+
+	if ac.TransportDecorator != nil {
+		authenticatedClient.Transport = ac.TransportDecorator(
+			authenticatedClient.Transport)
+	}
+
 	customTransport := httptransport.NewWithClient(
 		ac.Host(), ac.BasePath(), []string{}, authenticatedClient)
 	customTransport.Debug = ac.Debug
@@ -92,3 +98,8 @@ func (w *workaround) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	return w.T.RoundTrip(req)
 }
+
+// TransportDecorator accepts a RoundTripper and returns a RoundTripper.
+// This can be used to wrap or decorate the authenticated client's built-in
+// HTTP client operation behavior for all API requests.
+type TransportDecorator func(http.RoundTripper) http.RoundTripper

--- a/falcon/api_config.go
+++ b/falcon/api_config.go
@@ -28,7 +28,8 @@ type ApiConfig struct {
 	HttpTimeOutOverride *time.Duration
 	// UserAgentOverride allows to override default User-Agent HTTP header when talking with CrowdStrike API (default: gofalcon/$VERSION)
 	UserAgentOverride string
-
+	// TransportDecorator allows users to decorate and customize default authenticated client http.RoundTripper behavior.
+	TransportDecorator TransportDecorator
 	// Debug forces print out of all http traffic going through the API Runtime
 	Debug bool
 }


### PR DESCRIPTION
Create a falcon.TransportDecorator type to expose the ability to decorate the transport for all client requests to the Falcon API, and provide an example of how to use it in consumer code.