### PR TITLE
Add NewStreamWithClient method to allow injection of *http.Client before stream is opened

### DIFF
--- a/falcon/api_streaming.go
+++ b/falcon/api_streaming.go
@@ -27,6 +27,27 @@ type StreamingHandle struct {
 	HTTPClient *http.Client
 }
 
+// NewStreamWithClient initializes new StreamingHandle and connects to the Streaming API, providing an http.Client to make the connection.
+func NewStreamWithClient(ctx context.Context, client *client.CrowdStrikeAPISpecification, appId string, stream *models.MainAvailableStreamV2, offset uint64, httpClient *http.Client) (*StreamingHandle, error) {
+	sh := &StreamingHandle{
+		ctx:        ctx,
+		client:     client,
+		appId:      appId,
+		stream:     stream,
+		offset:     offset,
+		Events:     make(chan *streaming_models.EventItem),
+		Errors:     make(chan StreamingError),
+		HTTPClient: httpClient,
+	}
+	sh.maintainSession()
+	err := sh.open()
+	if err != nil {
+		sh.Close()
+		return nil, err
+	}
+	return sh, nil
+}
+
 // NewStream initializes new StreamingHandle and connects to the Streaming API.
 // The streams need to be discovered first by event_streams.ListAvailableStreamsOAuth2() method.
 // The appId must be an ID that is unique within your CrowdStrike account. Each running instance of your application must provide unique ID.


### PR DESCRIPTION
The current constructor/factory method calls `sh.open()` before the client is returned to the caller. This new constructor/factory method lets the user pass a `*http.Client` before the `sh.open()` call.