### PR TITLE
align headers with other crowdstrike SDK's

### DIFF
--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -69,6 +69,7 @@ type roundTripper struct {
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Add("User-Agent", rt.UserAgent)
+	req.Header.Add("CrowdStrike-SDK", "crowdstrike-gofalcon/"+Version.String())
 
 	if rt.LastRateLimitDigits == 1 || rt.LastRateLimitDigits == 2 {
 		log.Debug("Approaching CrowdStrike API rate limits. Waiting 500 millisecond.")

--- a/falcon/api_config.go
+++ b/falcon/api_config.go
@@ -57,7 +57,7 @@ func (ac *ApiConfig) HttpTimeout() time.Duration {
 	return *ac.HttpTimeOutOverride
 }
 
-var userAgent = "gofalcon/" + Version.String()
+var userAgent = "crowdstrike-gofalcon/" + Version.String()
 
 func (ac *ApiConfig) UserAgent() string {
 	// If you are editing this part of the code, you may want to familiarise yourself with


### PR DESCRIPTION
- Updates User-Agent header to: `crowdstrike-falcon/*`
- Adds the `CrowdStrike-SDK` header