### PR TITLE
require `Cloud` when using `AccessToken`

### DIFF
--- a/examples/simple_access_token/README.md
+++ b/examples/simple_access_token/README.md
@@ -1,10 +1,15 @@
-# Simple
+# Auth with Access Token
 
-Minimalist example to showcase authentication and initialisation of client library using an existing access token. The very latest [CrowdStrike Score](https://www.crowdstrike.com/blog/tech-center/crowdscore-efficiency/) is shown.
+Minimalist example to showcase authentication and initialization of client library using an existing access token. The very latest [CrowdStrike Score](https://www.crowdstrike.com/blog/tech-center/crowdscore-efficiency/) is shown.
 
 Example run:
 ```
-$ FALCON_ACCESS_TOKEN="abc" \
+FALCON_ACCESS_TOKEN="abc" \
+FALCON_CLOUD="us-1" \
         go run github.com/crowdstrike/gofalcon/examples/simple_access_token
+```
+
+Example output:
+```
 As of 2021-01-29T13:47:55.362Z your CrowdScore is 0.
 ```

--- a/examples/simple_access_token/README.md
+++ b/examples/simple_access_token/README.md
@@ -1,4 +1,4 @@
-# Auth with Access Token
+# Authentication with Access Token
 
 Minimalist example to showcase authentication and initialization of client library using an existing access token. The very latest [CrowdStrike Score](https://www.crowdstrike.com/blog/tech-center/crowdscore-efficiency/) is shown.
 

--- a/examples/simple_access_token/main.go
+++ b/examples/simple_access_token/main.go
@@ -12,13 +12,19 @@ import (
 
 func main() {
 	falconAccessToken := os.Getenv("FALCON_ACCESS_TOKEN")
+	falconCloud := os.Getenv("FALCON_CLOUD")
 	if falconAccessToken == "" {
 		falconAccessToken = falcon_util.PromptUser(`Missing FALCON_ACCESS_TOKEN environment variable. Please provide your OAuth2 API Access Token for authentication with CrowdStrike Falcon platform`)
+	}
+
+	if falconCloud == "" {
+		falconCloud = falcon_util.PromptUser(`Missing FALCON_CLOUD environment variable. Please provide your CrowdStrike Falcon cloud region (us-1, us-2, eu-1, us-gov-1, etc).`)
 	}
 
 	client, err := falcon.NewClient(&falcon.ApiConfig{
 		AccessToken: falconAccessToken,
 		Context:     context.Background(),
+		Cloud:       falcon.Cloud(falconCloud),
 	})
 	if err != nil {
 		panic(err)

--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -31,9 +31,7 @@ func NewClient(ac *ApiConfig) (*client.CrowdStrikeAPISpecification, error) {
 		}
 	} else if ac.Cloud == CloudAutoDiscover {
 		// There is nothing in the access token (JWT) which identifies the cloud.
-		// API gateway can determine the appropriate cloud based off the client ID.
-		// Forwarding to US-1 as a default.
-		ac.Cloud = CloudUs1
+		return nil, errors.New("Cannot autodiscover cloud when using an access token. Please specify the cloud explicitly.")
 	}
 
 	var authenticatedClient *http.Client

--- a/falcon/api_config.go
+++ b/falcon/api_config.go
@@ -23,7 +23,8 @@ type ApiConfig struct {
 	MemberCID string
 	// This Context object will be used only when authenticating with the OAuth interface.
 	Context context.Context
-	// Cloud allows us to select Falcon Cloud to connect
+	// Cloud allows us to select Falcon Cloud to connect.
+	// *required* if AccessToken is used.
 	Cloud CloudType
 	// HostOverride allows to override default host (default: api.crowdstrike.com)
 	HostOverride string

--- a/falcon/cloud.go
+++ b/falcon/cloud.go
@@ -21,13 +21,13 @@ const (
 	CloudUsGov1
 )
 
-// Cloud parses clould string (example: us-1, us-2, eu-1, us-gov-1, etc). If a string is not recognised CloudUs1 is returned.
+// Cloud parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc). If a string is not recognized CloudUs1 is returned.
 func Cloud(cloudString string) CloudType {
 	c, _ := CloudValidate(cloudString)
 	return c
 }
 
-// CloudValidate parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc.). Error is returned when string cannot be recognised
+// CloudValidate parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc.). Error is returned when string cannot be recognized.
 func CloudValidate(cloudString string) (CloudType, error) {
 	trimmed := strings.TrimSpace(cloudString)
 	lower := strings.ToLower(trimmed)


### PR DESCRIPTION
related to #357 

current users of the sdk expect autodiscover to use the correct cloud to prevent redirects. This change ensures users know we can not auto discover the cloud when using AccessToken

