### PR TITLE
use context to correctly close stream connections

### DIFF
--- a/falcon/api_streaming.go
+++ b/falcon/api_streaming.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/crowdstrike/gofalcon/falcon/client"
@@ -117,13 +116,17 @@ func (sh *StreamingHandle) open() error {
 			err := resp.Body.Close()
 
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error while closing the streaming connection: %v", err)
+				sh.Errors <- StreamingError{
+					Fatal: false,
+					Err:   err,
+				}
 			}
 
 			sh.Errors <- StreamingError{
 				Fatal: true,
 				Err:   errors.New("streaming connection closed"),
 			}
+
 			close(sh.Errors)
 			close(sh.Events)
 		}()
@@ -143,7 +146,6 @@ func (sh *StreamingHandle) open() error {
 					sh.Events <- &detection
 				}
 			}
-
 		}
 	}()
 


### PR DESCRIPTION
This PR fixes #363 

Currently calling `StreamHandle.Close()` does not terminate all connections. This PR uses `Context` to cancel all goroutines when `Close` is called

This PR also fixes #346 

Instead of closing the errors channel in the `Close` method it is moved to the `open` method since `open` is the one writing to the channel it should decide when the channel should be closed. 

This PR also removes the the print to stderr and replaces it with adding a error to the `errors` channel. All closing logic is now called in a defer.