### PR TITLE
fix saved-searches execute and results response payload

### DIFF
--- a/falcon/models/apidomain_query_response_wrapper_v1.go
+++ b/falcon/models/apidomain_query_response_wrapper_v1.go
@@ -30,7 +30,7 @@ type ApidomainQueryResponseWrapperV1 struct {
 
 	// resources
 	// Required: true
-	Resources *ApidomainQueryResponseV1 `json:"resources"`
+	Resources []*ApidomainQueryResponseV1 `json:"resources"`
 }
 
 // Validate validates this apidomain query response wrapper v1
@@ -108,15 +108,22 @@ func (m *ApidomainQueryResponseWrapperV1) validateResources(formats strfmt.Regis
 		return err
 	}
 
-	if m.Resources != nil {
-		if err := m.Resources.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("resources")
-			}
-			return err
+	for i := 0; i < len(m.Resources); i++ {
+		if swag.IsZero(m.Resources[i]) { // not required
+			continue
 		}
+
+		if m.Resources[i] != nil {
+			if err := m.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -188,16 +195,24 @@ func (m *ApidomainQueryResponseWrapperV1) contextValidateMeta(ctx context.Contex
 
 func (m *ApidomainQueryResponseWrapperV1) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.Resources != nil {
+	for i := 0; i < len(m.Resources); i++ {
 
-		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("resources")
+		if m.Resources[i] != nil {
+
+			if swag.IsZero(m.Resources[i]) { // not required
+				return nil
 			}
-			return err
+
+			if err := m.Resources[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
 		}
+
 	}
 
 	return nil


### PR DESCRIPTION
The saved searches execute and results response payload is not aligned with the actual response from the API.  This was caused the service's Swagger being incorrect.  A correction to the Swagger has been issued.  This absorbs the Swagger change.