### PR TITLE
fix ioa exclusions creation returns 201 in case of success

### DIFF
--- a/falcon/client/ioa_exclusions/create_i_o_a_exclusions_v1_responses.go
+++ b/falcon/client/ioa_exclusions/create_i_o_a_exclusions_v1_responses.go
@@ -25,7 +25,7 @@ type CreateIOAExclusionsV1Reader struct {
 // ReadResponse reads a server response into the received o.
 func (o *CreateIOAExclusionsV1Reader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
-	case 200:
+	case 201:
 		result := NewCreateIOAExclusionsV1OK()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err


### PR DESCRIPTION
I noted that the endpoint `POST /policy/entities/ioa-exclusions/v1` returned code 201 in case of success. 
The gofalcon SDK expect a code 200. As a consequence, the CreateIOAExclusionsV1 methods returns an error even in case of a success.