### PR TITLE
Transform fixes for falconjs

### DIFF
--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -199,3 +199,24 @@
  | .definitions."models.Container".properties.first_seen.type = "string"
  | .definitions."models.Container".properties.last_seen.type = "string"
 
+# fix arrays of enums who define the enum outside of items
+| .paths."/kubernetes-protection/entities/kubernetes/clusters/v1".get.parameters[1].items.enum = .paths."/kubernetes-protection/entities/kubernetes/clusters/v1".get.parameters[1].enum
+| del(.paths."/kubernetes-protection/entities/kubernetes/clusters/v1".get.parameters[1].enum)
+
+| .paths."/kubernetes-protection/entities/cloud_cluster/v1".get.parameters[2].items.enum = .paths."/kubernetes-protection/entities/cloud_cluster/v1".get.parameters[2].enum
+| del(.paths."/kubernetes-protection/entities/cloud_cluster/v1".get.parameters[2].enum)
+
+| .paths."/kubernetes-protection/entities/cloud_cluster/v1".get.parameters[3].items.enum = .paths."/kubernetes-protection/entities/cloud_cluster/v1".get.parameters[3].enum
+| del(.paths."/kubernetes-protection/entities/cloud_cluster/v1".get.parameters[3].enum)
+
+| .paths."/kubernetes-protection/entities/cloud-locations/v1".get.parameters[0].items.enum = .paths."/kubernetes-protection/entities/cloud-locations/v1".get.parameters[0].enum
+| del(.paths."/kubernetes-protection/entities/cloud-locations/v1".get.parameters[0].enum)
+
+| .paths."/policy/combined/sensor-update-builds/v1".get.parameters[1].items.enum = .paths."/policy/combined/sensor-update-builds/v1".get.parameters[1].enum
+| del(.paths."/policy/combined/sensor-update-builds/v1".get.parameters[1].enum)
+
+# remove duplicate parameters (one upper, one lower)
+| del(.definitions."apidomain.SavedSearchExecuteRequestV1".properties.parameters)
+
+# ensure access token is required to avoid optional typing in typescript
+| .definitions."domain.AccessTokenResponseV1".required = ["access_token"]


### PR DESCRIPTION
Three types of fixes:

1. Parameters of type array that define an `enum` at the parameter root, versus on the `items` of the parameter, are incorrect since the root `enum` would define possible array values. We want to define possible values for strings in the array. Move those `enum`s under `item`s. **NOTE:** the parameter index is hardcoded...I see this done one other place in the file already but it makes me nervous. There is probably a smarter way to search for an array element with a value?
2. `SavedSearchExecuteRequestV1` defined `Parameters` object with string values and another `parameters` object with no defined value. Prefer the uppercase one since it's more specific.
3. `AccessTokenResponseV1` doesn't define any required fields, so in typescript the `accessToken` is `string | undefined`. This makes it incompatible with `string`s. Seems like if we have a token response, it's definitely going to have a token in it.