### PR TITLE
Update README.md for Developer Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Golang-based SDK to CrowdStrike's Falcon APIs.
 
-Gofalcon documentation is available on [pkg.go.dev](https://pkg.go.dev/github.com/crowdstrike/gofalcon). Users are advised to consult this gofalcon documentation together with the comprehensive CrowdStrike API documentation published on [Developer Portal](https://developer.crowdstrike.com/crowdstrike/docs). The easiest way to learn about the SDK is to consult the set of [examples](examples) built on top of the SDK. What follows is a subset of these examples that can be found useful as stand-alone programs.
+Gofalcon documentation is available on [pkg.go.dev](https://pkg.go.dev/github.com/crowdstrike/gofalcon). Users are advised to consult this gofalcon documentation together with the comprehensive CrowdStrike API documentation published on [Developer Center](https://developer.crowdstrike.com/docs/openapi). The easiest way to learn about the SDK is to consult the set of [examples](examples) built on top of the SDK. What follows is a subset of these examples that can be found useful as stand-alone programs.
 
 | Example                                                                       | Description                                                                                                                         |
 | :--------                                                                     | :------------                                                                                                                       |


### PR DESCRIPTION
## Description

The Developer Portal is being deprecated in favor of the Developer Center, which doesn't require authentication.

## Changes

Change from Developer Portal to Developer Center and link to API docs page, which looks as follows.

<img width="1396" alt="Screenshot 2024-09-11 at 8 47 43 AM" src="https://github.com/user-attachments/assets/1a38e0cb-d95a-40d2-9e6b-8068b70fcc0a">

## Additional Notes

The Developer Center hasn't launched yet, which is why this PR is in draft form.
