### PR TITLE
Add element for Tech-Alert-Detection-Summary-Event-Field-Changes.

### DIFF
--- a/falcon/models/streaming_models/models.go
+++ b/falcon/models/streaming_models/models.go
@@ -27,7 +27,9 @@ type Event struct {
 	Success           *bool   `json:"Success,omitempty"`
 	ComputerName      *string `json:"ComputerName,omitempty"`
 	DetectDescription *string `json:"DetectDescription,omitempty"`
+	Description       *string `json:"Description,omitempty"`
 	DetectID          *string `json:"DetectId,omitempty"`
+	CompositeId       *string `json:"CompositeId,omitempty"`
 	FalconHostLink    *string `json:"FalconHostLink,omitempty"`
 
 	IOARuleInstanceId      *string      `json:"IOARuleInstanceId,omitempty"`
@@ -42,6 +44,7 @@ type Event struct {
 	ProcessId                     *IntOrString             `json:"ProcessId,omitempty"`
 	UserName                      *string                  `json:"UserName,omitempty"`
 	DetectName                    *string                  `json:"DetectName,omitempty"`
+	Name                          *string                  `json:"Name,omitempty"`
 	CommandLine                   *string                  `json:"CommandLine,omitempty"`
 	MD5                           *string                  `json:"MD5String,omitempty"`
 	SHA1                          *string                  `json:"SHA1String,omitempty"`


### PR DESCRIPTION
Perhaps add a new element after Oct 1st 2024, as we recognize that a new element will be needed after Oct 1st 2024.
ref: https://supportportal.crowdstrike.com/s/article/Tech-Alert-Detection-Summary-Event-Field-Changes

* `CompositeId`
* `Name`
* `Description`

We may be able to delete the old data after Oct 1st, but we will keep the old data to ensure a stable API migration.