### PR TITLE
feat: add additional containers to interact with

### DIFF
--- a/falcon/containers.go
+++ b/falcon/containers.go
@@ -12,26 +12,10 @@ const (
 	KacSensor      SensorType = "falcon-kac"
 	NodeSensor     SensorType = "falcon-sensor"
 	Snapshot       SensorType = "falcon-snapshot"
-	KPAgent        SensorType = "kpagent"
 	FCSCli         SensorType = "fcs"
 	SHRAController SensorType = "falcon-jobcontroller"
 	SHRAExecutor   SensorType = "falcon-registryassessmentexecutor"
 )
-
-// AllSensorTypes returns all available sensor types
-func AllSensorTypes() []SensorType {
-    return []SensorType{
-        SidecarSensor,
-        ImageSensor,
-        KacSensor,
-        NodeSensor,
-        Snapshot,
-        KPAgent,
-        FCSCli,
-        SHRAController,
-        SHRAExecutor,
-    }
-}
 
 // FalconContainerUploadURI parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc) and returns a URI for uploading a container image for ImageAssessment.
 func FalconContainerUploadURI(falconCloud CloudType) string {
@@ -66,14 +50,12 @@ func FalconContainerSensorImageURI(falconCloud CloudType, sensorType SensorType)
 		return fmt.Sprintf("%s/falcon-sensor/%s/release/falcon-sensor", registryFQDN(falconCloud), registryCloud(falconCloud))
 	case Snapshot:
 		return fmt.Sprintf("%s/falcon-snapshot/%s/release/cs-snapshotscanner", registryFQDN(falconCloud), registryCloud(falconCloud))
-	case KPAgent:
-		return fmt.Sprintf("%s/kubernetes_protection/kpagent", registryFQDN(falconCloud))
 	case FCSCli:
 		return fmt.Sprintf("%s/fcs/%s/release/cs-fcs", registryFQDN(falconCloud), registryCloud(falconCloud))
 	case SHRAController:
-		return fmt.Sprintf("%s/falcon-selfhostedregistryassessment/%s/release/falcon-jobcontroller", registryFQDN(falconCloud), registryCloud(falconCloud))
+		return fmt.Sprintf("%s/falcon-selfhostedregistryassessment/release/falcon-jobcontroller", registryFQDN(falconCloud))
 	case SHRAExecutor:
-		return fmt.Sprintf("%s/falcon-selfhostedregistryassessment/%s/release/falcon-registryassessmentexecutor", registryFQDN(falconCloud), registryCloud(falconCloud))
+		return fmt.Sprintf("%s/falcon-selfhostedregistryassessment/release/falcon-registryassessmentexecutor", registryFQDN(falconCloud))
 	default:
 		return fmt.Sprintf("%s/falcon-sensor/%s/release/falcon-sensor", registryFQDN(falconCloud), registryCloud(falconCloud))
 	}

--- a/falcon/containers.go
+++ b/falcon/containers.go
@@ -7,10 +7,15 @@ import (
 type SensorType string
 
 const (
-	SidecarSensor SensorType = "falcon-container"
-	ImageSensor   SensorType = "falcon-imageanalyzer"
-	KacSensor     SensorType = "falcon-kac"
-	NodeSensor    SensorType = "falcon-sensor"
+	SidecarSensor  SensorType = "falcon-container"
+	ImageSensor    SensorType = "falcon-imageanalyzer"
+	KacSensor      SensorType = "falcon-kac"
+	NodeSensor     SensorType = "falcon-sensor"
+	Snapshot       SensorType = "falcon-snapshot"
+	KPAgent        SensorType = "kpagent"
+	FCSCli         SensorType = "fcs"
+	SHRAController SensorType = "falcon-jobcontroller"
+	SHRAExecutor   SensorType = "falcon-registryassessmentexecutor"
 )
 
 // FalconContainerUploadURI parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc) and returns a URI for uploading a container image for ImageAssessment.
@@ -44,6 +49,16 @@ func FalconContainerSensorImageURI(falconCloud CloudType, sensorType SensorType)
 		return fmt.Sprintf("%s/falcon-kac/%s/release/falcon-kac", registryFQDN(falconCloud), registryCloud(falconCloud))
 	case NodeSensor:
 		return fmt.Sprintf("%s/falcon-sensor/%s/release/falcon-sensor", registryFQDN(falconCloud), registryCloud(falconCloud))
+	case Snapshot:
+		return fmt.Sprintf("%s/falcon-snapshot/%s/release/cs-snapshotscanner", registryFQDN(falconCloud), registryCloud(falconCloud))
+	case KPAgent:
+		return fmt.Sprintf("%s/kubernetes_protection/kpagent", registryFQDN(falconCloud))
+	case FCSCli:
+		return fmt.Sprintf("%s/fcs/%s/release/cs-fcs", registryFQDN(falconCloud), registryCloud(falconCloud))
+	case SHRAController:
+		return fmt.Sprintf("%s/falcon-selfhostedregistryassessment/%s/release/falcon-jobcontroller", registryFQDN(falconCloud), registryCloud(falconCloud))
+	case SHRAExecutor:
+		return fmt.Sprintf("%s/falcon-selfhostedregistryassessment/%s/release/falcon-registryassessmentexecutor", registryFQDN(falconCloud), registryCloud(falconCloud))
 	default:
 		return fmt.Sprintf("%s/falcon-sensor/%s/release/falcon-sensor", registryFQDN(falconCloud), registryCloud(falconCloud))
 	}

--- a/falcon/containers.go
+++ b/falcon/containers.go
@@ -18,6 +18,21 @@ const (
 	SHRAExecutor   SensorType = "falcon-registryassessmentexecutor"
 )
 
+// AllSensorTypes returns all available sensor types
+func AllSensorTypes() []SensorType {
+    return []SensorType{
+        SidecarSensor,
+        ImageSensor,
+        KacSensor,
+        NodeSensor,
+        Snapshot,
+        KPAgent,
+        FCSCli,
+        SHRAController,
+        SHRAExecutor,
+    }
+}
+
 // FalconContainerUploadURI parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc) and returns a URI for uploading a container image for ImageAssessment.
 func FalconContainerUploadURI(falconCloud CloudType) string {
 	switch falconCloud {

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -38,7 +38,7 @@
 
   # Add response code "202" to "/devices/entities/devices/tags/v1" endpoint
   | .paths."/devices/entities/devices/tags/v1".patch.responses."202" = .paths."/devices/entities/devices/tags/v1".patch.responses."200"
-  
+
 
   # CGP should be Gcp
   | .paths."/cloud-connect-gcp/entities/account/v1".get.operationId = "GetD4CGcpAccount"
@@ -49,14 +49,14 @@
   # looks like spotlight is staying to reverting it again... keeping this code incase it can be used some other time.
   # | walk(
   #     if type == "object" and .tags and (.tags | index("spotlight-vulnerabilities")) then
-  #       .tags |= map(gsub("spotlight-vulnerabilities"; "vulnerabilities")) 
+  #       .tags |= map(gsub("spotlight-vulnerabilities"; "vulnerabilities"))
   #     elif type == "object" and .tags and (.tags | index("spotlight-evaluation-logic")) then
-  #       .tags |= map(gsub("spotlight-evaluation-logic"; "vulnerabilities-evaluation-logic")) 
-  #     else 
+  #       .tags |= map(gsub("spotlight-evaluation-logic"; "vulnerabilities-evaluation-logic"))
+  #     else
   #       .
   #     end
   #   )
-  
+
   # Revert msaspec.QueryResponse back to msa.QueryResponse for falconcomplete-dashboard
   | if .paths."/falcon-complete-dashboards/queries/alerts/v1".get.responses."200".schema."$ref" = "#/definitions/msaspec.QueryResponse" then .paths."/falcon-complete-dashboards/queries/alerts/v1".get.responses."200".schema |= {"$ref": "#/definitions/msa.QueryResponse"} else . end
   | if .paths."/falcon-complete-dashboards/queries/devicecount-collections/v1".get.responses."200".schema."$ref" = "#/definitions/msaspec.QueryResponse" then .paths."/falcon-complete-dashboards/queries/devicecount-collections/v1".get.responses."200".schema |= {"$ref": "#/definitions/msa.QueryResponse"} else . end
@@ -68,43 +68,43 @@
   | if .paths."/falcon-complete-dashboards/queries/remediations/v1".get.responses."200".schema."$ref" = "#/definitions/msaspec.QueryResponse" then .paths."/falcon-complete-dashboards/queries/remediations/v1".get.responses."200".schema |= {"$ref": "#/definitions/msa.QueryResponse"} else . end
 
   # Revert changes.GetChangesResponse back to public.GetChangesResponse for filevantage
-  | if .paths."/filevantage/entities/changes/v2".get.responses."200".schema."$ref" = "#/definitions/changes.GetChangesResponse" then 
-      .paths."/filevantage/entities/changes/v2".get.responses."200".schema = {"$ref": "#/definitions/public.GetChangesResponse"} 
-      |.definitions."public.GetChangesResponse" = .definitions."changes.GetChangesResponse" 
+  | if .paths."/filevantage/entities/changes/v2".get.responses."200".schema."$ref" = "#/definitions/changes.GetChangesResponse" then
+      .paths."/filevantage/entities/changes/v2".get.responses."200".schema = {"$ref": "#/definitions/public.GetChangesResponse"}
+      |.definitions."public.GetChangesResponse" = .definitions."changes.GetChangesResponse"
       |del(.definitions."changes.GetChangesResponse") else . end
 
   # Make message-center use consistent return type
-  | if .paths."/message-center/aggregates/cases/GET/v1".post.responses."403".schema."$ref" = "#/definitions/msa.ReplyMetaOnly" then 
-      .paths."/message-center/aggregates/cases/GET/v1".post.responses."403".schema = {"$ref": "#/definitions/msaspec.ResponseFields"} 
-    else . end 
+  | if .paths."/message-center/aggregates/cases/GET/v1".post.responses."403".schema."$ref" = "#/definitions/msa.ReplyMetaOnly" then
+      .paths."/message-center/aggregates/cases/GET/v1".post.responses."403".schema = {"$ref": "#/definitions/msaspec.ResponseFields"}
+    else . end
 
   # Custom Storage "custom-type" rename
   | .definitions."CustomStorageObjectKeys" = .definitions."CustomType_1255839303"
   | del(.definitions."CustomType_1255839303")
-  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".get.responses."200".schema."$ref" = "#/definitions/CustomType_1255839303" then 
-      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageObjectKeys"}  else . end 
-  | if .paths."/customobjects/v1/collections/{collection_name}/objects".get.responses."200".schema."$ref" = "#/definitions/CustomType_1255839303" then 
-      .paths."/customobjects/v1/collections/{collection_name}/objects".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageObjectKeys"}  else . end 
+  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".get.responses."200".schema."$ref" = "#/definitions/CustomType_1255839303" then
+      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageObjectKeys"}  else . end
+  | if .paths."/customobjects/v1/collections/{collection_name}/objects".get.responses."200".schema."$ref" = "#/definitions/CustomType_1255839303" then
+      .paths."/customobjects/v1/collections/{collection_name}/objects".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageObjectKeys"}  else . end
 
   | .definitions."CustomStorageResponse" = .definitions."CustomType_3191042536"
   | del(.definitions."CustomType_3191042536")
-  | if .paths."/customobjects/v1/collections/{collection_name}/objects".post.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
+  | if .paths."/customobjects/v1/collections/{collection_name}/objects".post.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
       .paths."/customobjects/v1/collections/{collection_name}/objects".post.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
-  | if .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".put.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
-      .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".put.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end 
-  | if .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".delete.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
-      .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".delete.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end 
-  | if .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}/metadata".get.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
-      .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}/metadata".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end 
-  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".post.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
-      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".post.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end 
-  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".put.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
-      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".put.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end 
-  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".delete.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
-      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".delete.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end 
-  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}/metadata".get.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then 
-      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}/metadata".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end 
-  
+  | if .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".put.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
+      .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".put.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
+  | if .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".delete.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
+      .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".delete.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
+  | if .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}/metadata".get.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
+      .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}/metadata".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
+  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".post.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
+      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects".post.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
+  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".put.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
+      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".put.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
+  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".delete.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
+      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}".delete.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
+  | if .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}/metadata".get.responses."200".schema."$ref" = "#/definitions/CustomType_3191042536" then
+      .paths."/customobjects/v1/collections/{collection_name}/{collection_version}/objects/{object_key}/metadata".get.responses."200".schema = {"$ref": "#/definitions/CustomStorageResponse"}  else . end
+
   # Better operationId for workflows collection
   | .paths."/workflows/entities/execute/v1".post.operationId = "Execute"
   | .paths."/workflows/entities/execution-actions/v1".post.operationId = "ExecutionAction"
@@ -123,7 +123,7 @@
   | .paths."/loggingapi/entities/saved-searches/job-results-download/v1".get.operationId = "DownloadResults"
   | .paths."/loggingapi/entities/views/v1".get.operationId = "ListViews"
 
-  # Better operationId for custom-storage collection  
+  # Better operationId for custom-storage collection
   | .paths."/customobjects/v1/collections/{collection_name}/objects".get.operationId = "list"
   | .paths."/customobjects/v1/collections/{collection_name}/objects".post.operationId = "search"
   | .paths."/customobjects/v1/collections/{collection_name}/objects/{object_key}".get.operationId = "get"
@@ -546,7 +546,53 @@
   }
 }
 
-# Prevent unnecessary renaming 
+# Add new credential definitions for nested response structure
+| .definitions."common.Credentials" = {
+    "type": "object",
+    "properties": {
+        "meta": {
+            "$ref": "#/definitions/msa.MetaInfo"
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            },
+            "required": ["token"]
+        },
+        "errors": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/msa.APIError"
+            }
+        }
+    }
+}
+| .definitions."common.RegistryCredentialsResponse" = {
+    "required": [
+        "errors",
+        "meta",
+        "resources"
+    ],
+    "properties": {
+        "errors": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/msa.APIError"
+            }
+        },
+        "meta": {
+            "$ref": "#/definitions/msa.MetaInfo"
+        },
+        "resources": {
+            "$ref": "#/definitions/common.Credentials"
+        }
+    }
+}
+
+# Prevent unnecessary renaming
 | .paths."/snapshots/entities/image-registry-credentials/v1".get.operationId = "GetCredentialsMixin0Mixin60"
 | .paths."/falconx/queries/submissions/v1".get.operationId = "QuerySubmissions"
 | .paths."/scanner/queries/scans/v1".get.operationId = "QuerySubmissionsMixin0"


### PR DESCRIPTION
This PR adds the following containers that were missing from the `containers.go` helper file:
- Snapshot       SensorType = "falcon-snapshot"
- FCSCli         SensorType = "fcs"
- SHRAController SensorType = "falcon-jobcontroller"
- SHRAExecutor   SensorType = "falcon-registryassessmentexecutor"