### PR TITLE
feat: don't require dash when passing cloud and provide comments on handling autodiscover with container URIs

### DIFF
--- a/falcon/cloud.go
+++ b/falcon/cloud.go
@@ -32,19 +32,21 @@ func Cloud(cloudString string) CloudType {
 // CloudValidate parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc.). Error is returned when string cannot be recognized.
 func CloudValidate(cloudString string) (CloudType, error) {
 	trimmed := strings.TrimSpace(cloudString)
-	lower := strings.ToLower(trimmed)
+	stripped := strings.ReplaceAll(trimmed, "-", "")
+	lower := strings.ToLower(stripped)
+
 	switch lower {
 	case "":
 		fallthrough
 	case "autodiscover":
 		return CloudAutoDiscover, nil
-	case "us-1":
+	case "us1":
 		return CloudUs1, nil
-	case "us-2":
+	case "us2":
 		return CloudUs2, nil
-	case "eu-1":
+	case "eu1":
 		return CloudEu1, nil
-	case "us-gov-1":
+	case "usgov1":
 		return CloudUsGov1, nil
 	case "gov1":
 		return CloudGov1, nil

--- a/falcon/containers.go
+++ b/falcon/containers.go
@@ -38,6 +38,8 @@ func FalconContainerUploadURI(falconCloud CloudType) string {
 }
 
 // FalconContainerSensorImageURI returns a URI for downloading a container sensor image. Defaults to the falcon-sensor image.
+// When the Falcon Cloud CloudType is set to CloudAutoDiscover, be sure to provide the results of ApiConfig.Cloud after the client
+// has been initialized to ensure the correct CloudType is used and not CloudAutoDiscover.
 func FalconContainerSensorImageURI(falconCloud CloudType, sensorType SensorType) string {
 	switch sensorType {
 	case SidecarSensor:


### PR DESCRIPTION
- Allows not having to pass the dash with the CloudValidate() function
- Updates code comments for how to handle autodiscover with the FalconContainerSensorImageURI() function