### PR TITLE
fix(linting): address various issues identified by linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ jobs:
         go-version: ${{ matrix.go-version }}
       id: go
 
+    - name: Force Windows Git to use LF for newlines
+      if: matrix.os == 'windows-latest'
+      run: git config --global core.autocrlf false
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,16 +26,11 @@ linters:
       - legacy
       - std-error-handling
     paths:
-      - third_party$
-      - builtin$
-      - examples$
-      - falcon/models/*
+      - falcon/
 formatters:
   enable:
     - gofmt
   exclusions:
     generated: lax
     paths:
-      - third_party$
-      - builtin$
-      - examples$
+      - falcon/

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -7,7 +7,7 @@ import (
 	"github.com/crowdstrike/gofalcon/pkg/falcon_util"
 )
 
-// CommonAuthFlags is a struct that holds common authentication flags used for most examples
+// CommonAuthFlags is a struct that holds common authentication flags used for most examples.
 type CommonAuthFlags struct {
 	ClientId     string
 	ClientSecret string
@@ -25,7 +25,7 @@ func (c *CommonAuthFlags) PromptForRequiredFlags() {
 	}
 }
 
-// SetupAuthFlags parses command line flags and returns a CommonAuthFlags struct
+// SetupAuthFlags parses command line flags and returns a CommonAuthFlags struct.
 func SetupAuthFlags() *CommonAuthFlags {
 	commonAuthFlags := CommonAuthFlags{}
 	flag.StringVar(&commonAuthFlags.ClientId, "client-id", os.Getenv("FALCON_CLIENT_ID"), "Client ID for accessing CrowdStrike Falcon Platform (default taken from FALCON_CLIENT_ID env)")
@@ -36,7 +36,7 @@ func SetupAuthFlags() *CommonAuthFlags {
 	return &commonAuthFlags
 }
 
-// HandleError panics when err is not nil
+// HandleError panics when err is not nil.
 func HandleError(err error) {
 	if err != nil {
 		panic(err)

--- a/examples/falcon_cspm_ioms/main.go
+++ b/examples/falcon_cspm_ioms/main.go
@@ -85,7 +85,7 @@ func GetIOMs(client *client.CrowdStrikeAPISpecification) (ioms []models.Registra
 		}
 
 		if res.Payload.Meta == nil && res.Payload.Meta.Pagination == nil && res.Payload.Meta.Pagination.NextToken == "" {
-			return ioms, errors.New("Cannot paginate IOMs, pagination information missing")
+			return ioms, errors.New("cannot paginate IOMs, pagination information missing")
 		}
 
 		nextToken = res.Payload.Meta.Pagination.NextToken

--- a/examples/falcon_intel_rules_download/main.go
+++ b/examples/falcon_intel_rules_download/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -92,10 +93,13 @@ func DownloadLatestRuleFile(client *client.CrowdStrikeAPISpecification, intelTyp
 	}, bufio.NewWriter(&buffer))
 
 	if err != nil {
-		if success := err.(*intel.GetLatestIntelRuleFileNotModified); success != nil {
+		var notModifiedErr *intel.GetLatestIntelRuleFileNotModified
+		if errors.As(err, &notModifiedErr) {
 			// File has not changed, return empty buffer
-			return nil, nil
+			return nil, nil //nolint:nilerr
 		}
+		// Handle other error cases
+		return nil, err
 	}
 	return &buffer, err
 }

--- a/examples/falcon_iocs/falcon_iocs.go
+++ b/examples/falcon_iocs/falcon_iocs.go
@@ -18,7 +18,7 @@ import (
 	"github.com/crowdstrike/gofalcon/pkg/falcon_util"
 )
 
-// getCrowdstrikeIOCs returns a list of all the Custom IOC values in the system
+// getCrowdstrikeIOCs returns a list of all the Custom IOC values in the system.
 func getCrowdstrikeIOCs(client *client.CrowdStrikeAPISpecification) ([]string, error) {
 	iocs := []string{}
 	var limit, offset, total int64
@@ -49,7 +49,7 @@ func getCrowdstrikeIOCs(client *client.CrowdStrikeAPISpecification) ([]string, e
 	return iocs, nil
 }
 
-// getIOCType returns the IOC type as supported by crowdstrike (domain, ipv4, ipv6, md5, sha256)
+// getIOCType returns the IOC type as supported by crowdstrike (domain, ipv4, ipv6, md5, sha256).
 func getIOCType(iocStr string) (string, error) {
 	var RegexIPv4 = regexp.MustCompile(`^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$`)
 	var RegexIPv6 = regexp.MustCompile(`(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))`)
@@ -79,7 +79,7 @@ func getIOCType(iocStr string) (string, error) {
 	}
 }
 
-// addCrowdStrikeIOC will add a supported iocs with an optional description
+// addCrowdStrikeIOC will add a supported iocs with an optional description.
 // defaults to an expiration date of 10 years & a severity of medium.
 // will detect on domains/ips and block on hashes. Retro detection enabled by default.
 func addCrowdStrikeIOCs(
@@ -149,7 +149,7 @@ func addCrowdStrikeIOC(
 }
 
 // searchCrowdStrikeIOC searches custom IOCs for an IOC and returns an id if found.
-// if no IOC is found, an empty string is returned
+// if no IOC is found, an empty string is returned.
 func _getCrowdStrikeIOCID(
 	iocStr string,
 	client *client.CrowdStrikeAPISpecification,
@@ -174,7 +174,7 @@ func _getCrowdStrikeIOCID(
 	return resources[0], nil
 }
 
-// deleteCrowdStrikeIOCs deletes IOCs from the system
+// deleteCrowdStrikeIOCs deletes IOCs from the system.
 func deleteCrowdStrikeIOCs(iocs []string, client *client.CrowdStrikeAPISpecification) error {
 	iocIDs := []string{}
 	for _, iocStr := range iocs {
@@ -195,7 +195,7 @@ func deleteCrowdStrikeIOCs(iocs []string, client *client.CrowdStrikeAPISpecifica
 	return nil
 }
 
-// deleteCrowdStrikeIOCs deletes a single IOC from the system
+// deleteCrowdStrikeIOCs deletes a single IOC from the system.
 func deleteCrowdStrikeIOC(iocStr string, client *client.CrowdStrikeAPISpecification) error {
 	return deleteCrowdStrikeIOCs([]string{iocStr}, client)
 }
@@ -252,12 +252,12 @@ func main() {
 	list := flag.Bool("list", false, "list all IOC values in the IOC management panel")
 	add := flag.String("add", "", "block an IOC (valid types: md5, sha256, domain, ipv4, ipv6)")
 	description := flag.String("description", "", "add a IOC description for blocking")
-	delete := flag.String("delete", "", "unblock an IOC, if present in the IOC management panel")
+	deleteIOC := flag.String("delete", "", "unblock an IOC, if present in the IOC management panel")
 	show := flag.String("show", "", "show details of given IOC")
 
 	flag.Parse()
 
-	if !*list && *add == "" && *delete == "" && *show == "" {
+	if !*list && *add == "" && *deleteIOC == "" && *show == "" {
 		flag.Usage()
 		return
 	}
@@ -295,8 +295,8 @@ func main() {
 		}
 	}
 
-	if *delete != "" {
-		err := deleteCrowdStrikeIOC(*delete, client)
+	if *deleteIOC != "" {
+		err := deleteCrowdStrikeIOC(*deleteIOC, client)
 		if err != nil {
 			panic(err)
 		}

--- a/examples/falcon_sensor_download/main.go
+++ b/examples/falcon_sensor_download/main.go
@@ -73,7 +73,7 @@ Falcon Client Secret`,
 		panic(err)
 	}
 
-	if *all == true {
+	if *all {
 		downloadAllSensors(client)
 	} else {
 		if *osName == "" {
@@ -294,12 +294,12 @@ func oneSensorPerOsVersion(
 
 func openFileForWriting(dir, filename string) (*os.File, error) {
 	if strings.Contains(filename, "/") {
-		return nil, fmt.Errorf("Refusing to download: '%s' includes '/' character", filename)
+		return nil, fmt.Errorf("refusing to download: '%s' includes '/' character", filename)
 	}
 	path := filepath.Join(dir, filename)
 	safeLocation := filepath.Clean(path)
 	if strings.Contains(safeLocation, "\\") || strings.Contains(safeLocation, "..") {
-		return nil, fmt.Errorf("Refusing to download: Path '%s' looks suspicious", safeLocation)
+		return nil, fmt.Errorf("refusing to download: Path '%s' looks suspicious", safeLocation)
 	}
 	return os.OpenFile(safeLocation, os.O_CREATE|os.O_WRONLY, 0600)
 }

--- a/examples/falcon_vulnerabilities/main.go
+++ b/examples/falcon_vulnerabilities/main.go
@@ -115,7 +115,8 @@ func queryVulnerabilities(client *client.CrowdStrikeAPISpecification, filter str
 			if response.Payload.Meta == nil && response.Payload.Meta.Pagination == nil && response.Payload.Meta.Pagination.Limit == nil {
 				panic("Cannot paginate Vulnerabilities, pagination information missing")
 			}
-			if *response.Payload.Meta.Pagination.Limit > int32(len(vulns)) {
+			// Convert limit to int (the wider type) to avoid overflow
+			if int(*response.Payload.Meta.Pagination.Limit) > len(vulns) {
 				// We have got less items than what was the limit. Meaning, this is last batch, continuation is futile.
 				break
 			} else {

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -48,5 +48,3 @@ Falcon Client Secret`)
 	fmt.Printf("As of %s your CrowdScore is %d.\n",
 		payload.Resources[0].Timestamp.String(), *payload.Resources[0].Score)
 }
-
-type void struct{}

--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -22,7 +22,7 @@ func NewClient(ac *ApiConfig) (*client.CrowdStrikeAPISpecification, error) {
 		return nil, err
 	}
 	if ac.Context == nil {
-		return nil, errors.New("Invalid Context for falcon.ApiConfig.Context. Make that ApiConfig.Context is set.")
+		return nil, errors.New("invalid context for falcon.ApiConfig.Context. Make that ApiConfig.Context is set")
 	}
 
 	// If HostOverride is provided we do not need to discover the cloud
@@ -33,7 +33,7 @@ func NewClient(ac *ApiConfig) (*client.CrowdStrikeAPISpecification, error) {
 			}
 		} else if ac.Cloud == CloudAutoDiscover {
 			// There is nothing in the access token (JWT) which identifies the cloud.
-			return nil, errors.New("Cannot autodiscover cloud when using an access token. Please specify the cloud explicitly.")
+			return nil, errors.New("cannot autodiscover cloud when using an access token. Please specify the cloud explicitly")
 		}
 	}
 
@@ -57,7 +57,7 @@ func credentialsOk(ac *ApiConfig) (bool, error) {
 	hasClientIDSecret := ac.ClientId != "" && ac.ClientSecret != ""
 
 	if (hasAccessToken && hasClientIDSecret) || (!hasAccessToken && !hasClientIDSecret) {
-		return false, errors.New("Must provide either an access token or a client ID and secret, but not both and not neither.")
+		return false, errors.New("must provide either an access token or a client ID and secret, but not both and not neither")
 	}
 	return true, nil
 }
@@ -126,7 +126,7 @@ type workaround struct {
 // This temporary workaround is needed as the recent go-openapi/runtime middleware
 // won't send the content-type while the CrowdStrike service requires it for a time being
 // https://github.com/go-openapi/runtime/commit/753b551e6b4a36e461ac877874fd0a79d0ffcf53
-// Streaming session refresh within examples/falcon_event_stream can be used trigger this code
+// Streaming session refresh within examples/falcon_event_stream can be used trigger this code.
 func (w *workaround) RoundTrip(req *http.Request) (*http.Response, error) {
 	contentType := req.Header.Get("Content-Type")
 	if contentType == "" {

--- a/falcon/api_config.go
+++ b/falcon/api_config.go
@@ -40,7 +40,7 @@ type ApiConfig struct {
 	Debug bool
 }
 
-// Host returns FQDN of CrowdStrike API Gateway to be used by this ApiConfig
+// Host returns FQDN of CrowdStrike API Gateway to be used by this ApiConfig.
 func (ac *ApiConfig) Host() string {
 	if ac.HostOverride != "" {
 		return ac.HostOverride
@@ -48,7 +48,7 @@ func (ac *ApiConfig) Host() string {
 	return ac.Cloud.Host()
 }
 
-// BasePath returns base URL path to be used by this ApiConfig
+// BasePath returns base URL path to be used by this ApiConfig.
 func (ac *ApiConfig) BasePath() string {
 	if ac.BasePathOverride == "" {
 		return client.DefaultBasePath

--- a/falcon/api_error.go
+++ b/falcon/api_error.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// AssertNoError converts MsaAPIError to golang errors
+// AssertNoError converts MsaAPIError to golang errors.
 // Falcon API oftentimes returns payload structure that may include application errors within MsaAPIError list.
 // For the users of the API it is often times desirable to convert the application errors from CrowdStrike platform to golang native errors to inform application flow.
 func AssertNoError(payloadErrors []*models.MsaAPIError) error {

--- a/falcon/api_streaming.go
+++ b/falcon/api_streaming.go
@@ -14,7 +14,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models/streaming_models"
 )
 
-// StreamingHandle is higher order type that allows for easy use of CrowdStrike Falcon Streaming API
+// StreamingHandle is higher order type that allows for easy use of CrowdStrike Falcon Streaming API.
 type StreamingHandle struct {
 	ctx           context.Context
 	ctxCancelFunc context.CancelFunc
@@ -152,7 +152,7 @@ func (sh *StreamingHandle) open() error {
 	return nil
 }
 
-// Close the StreamingHandle after use
+// Close the StreamingHandle after use.
 func (sh *StreamingHandle) Close() {
 	sh.ctxCancelFunc()
 	if sh.HTTPClient != nil {
@@ -167,7 +167,7 @@ func (sh *StreamingHandle) url() string {
 	return *sh.stream.DataFeedURL
 }
 
-// StreamingError structure that holds original error and indicates whether the Error is likely fatal or not
+// StreamingError structure that holds original error and indicates whether the Error is likely fatal or not.
 type StreamingError struct {
 	Fatal bool
 	Err   error

--- a/falcon/cloud.go
+++ b/falcon/cloud.go
@@ -113,16 +113,16 @@ func (c *CloudType) Autodiscover(ctx context.Context, clientId, clientSecret str
 		switch e := err.(type) {
 		case *oauth2.Oauth2AccessTokenForbidden:
 			if e.Payload != nil && len(e.Payload.Errors) == 1 && e.Payload.Errors[0] != nil && e.Payload.Errors[0].Message != nil && *e.Payload.Errors[0].Message == "access denied, authorization failed" {
-				return fmt.Errorf("Please check the settings of IP-based allowlisting in CrowdStrike Falcon Console. %s", e)
+				return fmt.Errorf("please check the settings of IP-based allowlisting in CrowdStrike Falcon Console. %s", e)
 			}
-			return fmt.Errorf("Insufficient CrowdStrike privileges, please grant [Falcon Images Download: Read] to CrowdStrike API Key. Error was: %s", err)
+			return fmt.Errorf("insufficient CrowdStrike privileges, please grant [Falcon Images Download: Read] to CrowdStrike API Key. Error was: %s", err)
 		}
-		return fmt.Errorf("Could not autodiscover Falcon cloud region: %v", err)
+		return fmt.Errorf("could not autodiscover Falcon cloud region: %v", err)
 	}
 	// (2) Parse & save the cloud-region information
 	cld, err := CloudValidate(token.XCSRegion)
 	if err != nil {
-		return fmt.Errorf("Could not validate Falcon cloud region '%s' during autodiscover: %v", token.XCSRegion, err)
+		return fmt.Errorf("could not validate Falcon cloud region '%s' during autodiscover: %v", token.XCSRegion, err)
 	}
 	(*c) = cld
 
@@ -140,7 +140,7 @@ func (c *CloudType) Autodiscover(ctx context.Context, clientId, clientSecret str
 		oauth2.AuthenticateRevocation(clientId, clientSecret),
 	)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr
 	}
 	if err = AssertNoError(revocation.Payload.Errors); err != nil {
 		return err

--- a/falcon/rtr.go
+++ b/falcon/rtr.go
@@ -266,7 +266,7 @@ func (r *RTR) NewSession(ctx context.Context, deviceID string) (*RTRSession, err
 		return nil, err
 	}
 	if len(response.Payload.Resources) != 1 {
-		return nil, fmt.Errorf("Unexpected return from RTRInitSession: %v", response)
+		return nil, fmt.Errorf("unexpected return from RTRInitSession: %v", response)
 	}
 	return &RTRSession{
 		client:      r.client,
@@ -315,7 +315,7 @@ func (s *RTRSession) Execute(ctx context.Context, baseCommand, commandString str
 		return nil, err
 	}
 	if len(response.Payload.Resources) != 1 {
-		return nil, fmt.Errorf("Expected one RTRExecuteResponse object got %d: %v", len(response.Payload.Resources), response.Payload.Resources)
+		return nil, fmt.Errorf("expected one RTRExecuteResponse object got %d: %v", len(response.Payload.Resources), response.Payload.Resources)
 	}
 	return response.Payload.Resources[0], nil
 }
@@ -336,7 +336,7 @@ func (s *RTRSession) ActiveResponderExecute(ctx context.Context, baseCommand, co
 		return nil, err
 	}
 	if len(response.Payload.Resources) != 1 {
-		return nil, fmt.Errorf("Expected one RTRExecuteActiveResponderResponse object got %d: %v", len(response.Payload.Resources), response.Payload.Resources)
+		return nil, fmt.Errorf("expected one RTRExecuteActiveResponderResponse object got %d: %v", len(response.Payload.Resources), response.Payload.Resources)
 	}
 	return response.Payload.Resources[0], nil
 }
@@ -357,7 +357,7 @@ func (s *RTRSession) AdminExecute(ctx context.Context, baseCommand, commandStrin
 		return nil, err
 	}
 	if len(response.Payload.Resources) != 1 {
-		return nil, fmt.Errorf("Expected one RTRExecuteActiveResponderResponse object got %d: %v", len(response.Payload.Resources), response.Payload.Resources)
+		return nil, fmt.Errorf("expected one RTRExecuteActiveResponderResponse object got %d: %v", len(response.Payload.Resources), response.Payload.Resources)
 	}
 	return response.Payload.Resources[0], nil
 }
@@ -382,7 +382,7 @@ func (s *RTRSession) WaitForExecution(ctx context.Context, cloudRequestId string
 			return nil, err
 		}
 		if len(response.Payload.Resources) != 1 {
-			return nil, fmt.Errorf("Unexpected return from RTRCheckActiverResponderCommandStatus: %v", response)
+			return nil, fmt.Errorf("unexpected return from RTRCheckActiverResponderCommandStatus: %v", response)
 		}
 		resource := *response.Payload.Resources[0]
 		*completeResponse.Stderr += falcon_util.DerefString(resource.Stderr)
@@ -419,7 +419,7 @@ func (s *RTRSession) ActiveResponderWaitForExecution(ctx context.Context, cloudR
 			return nil, err
 		}
 		if len(response.Payload.Resources) != 1 {
-			return nil, fmt.Errorf("Unexpected return from RTRCheckActiverResponderCommandStatus: %v", response)
+			return nil, fmt.Errorf("unexpected return from RTRCheckActiverResponderCommandStatus: %v", response)
 		}
 		resource := *response.Payload.Resources[0]
 		*completeResponse.Stderr += falcon_util.DerefString(resource.Stderr)
@@ -456,7 +456,7 @@ func (s *RTRSession) AdminWaitForExecution(ctx context.Context, cloudRequestId s
 			return nil, err
 		}
 		if len(response.Payload.Resources) != 1 {
-			return nil, fmt.Errorf("Unexpected return from RTRCheckActiverResponderCommandStatus: %v", response)
+			return nil, fmt.Errorf("unexpected return from RTRCheckActiverResponderCommandStatus: %v", response)
 		}
 		resource := *response.Payload.Resources[0]
 		*completeResponse.Stderr += falcon_util.DerefString(resource.Stderr)
@@ -639,7 +639,7 @@ func (r *RTR) PulseSession(ctx context.Context, request *models.DomainInitReques
 		return nil, err
 	}
 	if len(response.Payload.Resources) != 1 {
-		return nil, fmt.Errorf("Unexpected return from RTRPulseSession: %v", response)
+		return nil, fmt.Errorf("unexpected return from RTRPulseSession: %v", response)
 	}
 	return &RTRSession{
 		client:      r.client,


### PR DESCRIPTION
- Make sure comments end with a period (godot)
- Type assertion must be checked (forcetypeassert)
- G115: integer overflow conversion uint -> int (gosec)
- Ignore some errors where nil is not nil but returns a nil (nilerr)
- Fix variable delete had same name as predeclared identifier (predeclared)
- Fix error strings should not be capitalized (staticcheck)