### PR TITLE
fix: ngsiem API returns query costs as floats. closes #505

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ build:
 
 clean-generate: remove-generated generate
 
-generate: swagger-cli specs/swagger-stripped-oauth.json
-	$(SWAGGER) generate client --skip-validation -f $^ -t falcon
+generate: specs/swagger-stripped-oauth.json swagger-cli
+	$(SWAGGER) generate client --skip-validation -f $< -t falcon
 
 .PHONY: build generate remove-generated
 

--- a/falcon/models/costs.go
+++ b/falcon/models/costs.go
@@ -21,19 +21,19 @@ type Costs struct {
 
 	// The cost of execution of a live query
 	// Required: true
-	LiveCost *int64 `json:"liveCost"`
+	LiveCost *float64 `json:"liveCost"`
 
 	// The rate of the live cost query
 	// Required: true
-	LiveCostRate *int64 `json:"liveCostRate"`
+	LiveCostRate *float64 `json:"liveCostRate"`
 
 	// The cost for executing as a static query
 	// Required: true
-	StaticCost *int64 `json:"staticCost"`
+	StaticCost *float64 `json:"staticCost"`
 
 	// The rate for executing static queries
 	// Required: true
-	StaticCostRate *int64 `json:"staticCostRate"`
+	StaticCostRate *float64 `json:"staticCostRate"`
 }
 
 // Validate validates this costs

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -589,6 +589,12 @@
     }
 }
 
+# Ngsiem search metadata are ints but are returned from the API as decimals https://github.com/CrowdStrike/gofalcon/issues/505
+| .definitions.".costs".properties.liveCost.format = "float" | .definitions.".costs".properties.liveCost.type = "number"
+| .definitions.".costs".properties.liveCostRate.format = "float" | .definitions.".costs".properties.liveCostRate.type = "number"
+| .definitions.".costs".properties.staticCost.format = "float" | .definitions.".costs".properties.staticCost.type = "number"
+| .definitions.".costs".properties.staticCostRate.format = "float" | .definitions.".costs".properties.staticCostRate.type = "number"
+
 # Prevent unnecessary renaming
 | .paths."/snapshots/entities/image-registry-credentials/v1".get.operationId = "GetCredentialsMixin0Mixin60"
 | .paths."/falconx/queries/submissions/v1".get.operationId = "QuerySubmissions"


### PR DESCRIPTION
Cost fields appear to be ints (and are ints elsewhere in the humio docs) but are in fact returned as floats (and documented as `number`s in the humio docs).

Also fixes Makefile dynamically installing swagger by ensuring we only pass the patched JSON to the swagger CLI, not also the `swagger-cli` target name (introduced in #468).