### PR TITLE
chore: add regioned nodesensor type

### DIFF
--- a/falcon/containers.go
+++ b/falcon/containers.go
@@ -7,14 +7,15 @@ import (
 type SensorType string
 
 const (
-	SidecarSensor  SensorType = "falcon-container"
-	ImageSensor    SensorType = "falcon-imageanalyzer"
-	KacSensor      SensorType = "falcon-kac"
-	NodeSensor     SensorType = "falcon-sensor"
-	Snapshot       SensorType = "falcon-snapshot"
-	FCSCli         SensorType = "fcs"
-	SHRAController SensorType = "falcon-jobcontroller"
-	SHRAExecutor   SensorType = "falcon-registryassessmentexecutor"
+	SidecarSensor      SensorType = "falcon-container"
+	ImageSensor        SensorType = "falcon-imageanalyzer"
+	KacSensor          SensorType = "falcon-kac"
+	NodeSensor         SensorType = "falcon-sensor"
+	RegionedNodeSensor SensorType = "falcon-sensor-regioned"
+	Snapshot           SensorType = "falcon-snapshot"
+	FCSCli             SensorType = "fcs"
+	SHRAController     SensorType = "falcon-jobcontroller"
+	SHRAExecutor       SensorType = "falcon-registryassessmentexecutor"
 )
 
 // FalconContainerUploadURI parses cloud string (example: us-1, us-2, eu-1, us-gov-1, etc) and returns a URI for uploading a container image for ImageAssessment.
@@ -52,6 +53,8 @@ func FalconContainerSensorImageURI(falconCloud CloudType, sensorType SensorType)
 		return fmt.Sprintf("%s/falcon-kac/%s/release/falcon-kac", registryFQDN(falconCloud), registryCloud(falconCloud))
 	case NodeSensor:
 		return fmt.Sprintf("%s/falcon-sensor/release/falcon-sensor", registryFQDN(falconCloud))
+	case RegionedNodeSensor:
+		return fmt.Sprintf("%s/falcon-sensor/%s/release/falcon-sensor", registryFQDN(falconCloud), registryCloud(falconCloud))
 	case Snapshot:
 		return fmt.Sprintf("%s/falcon-snapshot/%s/release/cs-snapshotscanner", registryFQDN(falconCloud), registryCloud(falconCloud))
 	case FCSCli:


### PR DESCRIPTION
Provides a way for downstream users to get a non-unified sensor registry path until we no longer support regioned sensor images