### PR TITLE
Do not send uninitialized detection to Events in case of error

### DIFF
--- a/falcon/api_streaming.go
+++ b/falcon/api_streaming.go
@@ -167,11 +167,13 @@ func (sh *StreamingHandle) open() error {
 					err := dec.Decode(&rawMessage)
 					if err != nil {
 						sh.Errors <- StreamingError{Fatal: false, Err: err}
+						continue
 					}
 
 					err = json.Unmarshal(rawMessage, &detection)
 					if err != nil {
 						sh.Errors <- StreamingError{Fatal: false, Err: err}
+						continue
 					}
 
 					detection.RawMessage = rawMessage


### PR DESCRIPTION
Noticed that when I get "unexpected end of JSON input" error, I also get an event with offset: 0, which then ends up resetting my offset in the db causing to refetch all the events again.