### PR TITLE
Make domain.CIDGroup description field nullable

### DIFF
--- a/falcon/models/domain_c_id_group.go
+++ b/falcon/models/domain_c_id_group.go
@@ -27,7 +27,7 @@ type DomainCIDGroup struct {
 	CidGroupID *string `json:"cid_group_id"`
 
 	// description
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// is default
 	IsDefault bool `json:"is_default,omitempty"`

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -735,3 +735,6 @@
 
 # Make description nullable for common.CreateComplianceControlRequest
 | .definitions."common.CreateComplianceControlRequest".properties.description += {"x-nullable": true}
+
+# Make description nullable for domain.CIDGroup
+| .definitions."domain.CIDGroup".properties.description += {"x-nullable": true}


### PR DESCRIPTION
Allow empty string to be passed for the description field in domain.CIDGroup by making it x-nullable in the OpenAPI spec transformation.