### PR TITLE
chore: bump version to v0.20.0

### DIFF
--- a/falcon/version.go
+++ b/falcon/version.go
@@ -4,4 +4,4 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-var Version = semver.MustParse("0.19.0")
+var Version = semver.MustParse("0.20.0")


### PR DESCRIPTION
## Summary
- Bump SDK version from `0.19.0` to `0.20.0` in preparation for the next release