### PR TITLE
fix!: make IoaExclusionCreateReqV1 and IoaExclusionUpdateReqV1 detection_json field optional

### DIFF
--- a/falcon/models/ioa_exclusions_ioa_exclusion_create_req_v1.go
+++ b/falcon/models/ioa_exclusions_ioa_exclusion_create_req_v1.go
@@ -31,8 +31,7 @@ type IoaExclusionsIoaExclusionCreateReqV1 struct {
 	Description *string `json:"description"`
 
 	// detection json
-	// Required: true
-	DetectionJSON *string `json:"detection_json"`
+	DetectionJSON string `json:"detection_json,omitempty"`
 
 	// groups
 	// Required: true
@@ -64,10 +63,6 @@ func (m *IoaExclusionsIoaExclusionCreateReqV1) Validate(formats strfmt.Registry)
 	}
 
 	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateDetectionJSON(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -109,15 +104,6 @@ func (m *IoaExclusionsIoaExclusionCreateReqV1) validateClRegex(formats strfmt.Re
 func (m *IoaExclusionsIoaExclusionCreateReqV1) validateDescription(formats strfmt.Registry) error {
 
 	if err := validate.Required("description", "body", m.Description); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *IoaExclusionsIoaExclusionCreateReqV1) validateDetectionJSON(formats strfmt.Registry) error {
-
-	if err := validate.Required("detection_json", "body", m.DetectionJSON); err != nil {
 		return err
 	}
 

--- a/falcon/models/ioa_exclusions_ioa_exclusion_update_req_v1.go
+++ b/falcon/models/ioa_exclusions_ioa_exclusion_update_req_v1.go
@@ -31,8 +31,7 @@ type IoaExclusionsIoaExclusionUpdateReqV1 struct {
 	Description *string `json:"description"`
 
 	// detection json
-	// Required: true
-	DetectionJSON *string `json:"detection_json"`
+	DetectionJSON string `json:"detection_json,omitempty"`
 
 	// groups
 	// Required: true
@@ -68,10 +67,6 @@ func (m *IoaExclusionsIoaExclusionUpdateReqV1) Validate(formats strfmt.Registry)
 	}
 
 	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateDetectionJSON(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -117,15 +112,6 @@ func (m *IoaExclusionsIoaExclusionUpdateReqV1) validateClRegex(formats strfmt.Re
 func (m *IoaExclusionsIoaExclusionUpdateReqV1) validateDescription(formats strfmt.Registry) error {
 
 	if err := validate.Required("description", "body", m.Description); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *IoaExclusionsIoaExclusionUpdateReqV1) validateDetectionJSON(formats strfmt.Registry) error {
-
-	if err := validate.Required("detection_json", "body", m.DetectionJSON); err != nil {
 		return err
 	}
 

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -785,3 +785,7 @@
 | .definitions."policymanager.ExternalPolicyPatch".properties.precedence += {"x-nullable": true}
 | .definitions."policymanager.ExternalPolicyPost".required = ["description", "name"]
 | .definitions."policymanager.ExternalPolicyPost".properties.precedence += {"x-nullable": true}
+
+# Make detection_json optional for IOA exclusion create/update requests (API does not require it)
+| .definitions."ioa_exclusions.IoaExclusionCreateReqV1".required = ["cl_regex", "description", "groups", "ifn_regex", "name", "pattern_id", "pattern_name"]
+| .definitions."ioa_exclusions.IoaExclusionUpdateReqV1".required = ["cl_regex", "description", "groups", "id", "ifn_regex", "name", "pattern_id", "pattern_name"]


### PR DESCRIPTION
## Summary
- `detection_json` is incorrectly marked as required on `IoaExclusionCreateReqV1` and `IoaExclusionUpdateReqV1`, causing client-side validation failures when the field is nil
- Live API testing (us-2) confirms the field is not required for either create or update

Ref: CrowdStrike/terraform-provider-crowdstrike#326