### PR TITLE
feat: add native retry with exponential backoff

### DIFF
--- a/.github/workflows/check_spelling.yml
+++ b/.github/workflows/check_spelling.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Check Spelling
-      uses: SFLScientific/spellcheck-github-actions@master
+      uses: SFLScientific/spellcheck-github-actions@84072e1621c56777f2da246b5eddfcb18012720d

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ func main() {
 }
 ```
 
+## Retry and Backoff
+
+Gofalcon can automatically retry requests that fail with transient errors (network errors, `429 Too Many Requests`, `5xx` server errors) using exponential backoff. Enable it by setting `RetryConfig` on `ApiConfig`:
+
+```go
+client, err := falcon.NewClient(&falcon.ApiConfig{
+	ClientId:     os.Getenv("FALCON_CLIENT_ID"),
+	ClientSecret: os.Getenv("FALCON_CLIENT_SECRET"),
+	Context:      context.Background(),
+	RetryConfig: &falcon.RetryConfig{
+		MaxTries:        10,           // 0 = unlimited (retry until context cancellation)
+		InitialInterval: 2 * time.Second,
+		MaxInterval:     time.Minute,
+	},
+})
+```
+
+When `RetryConfig` is nil (the default), no retries are performed. Retry behaviour is controlled entirely by the context passed to `ApiConfig` -- cancelling the context stops any in-progress retry loop.
+
 ## Versioning
 
 This module adheres to the Go Module version numbering system, as described in detail at [Go Module version numbering](https://go.dev/doc/modules/version-numbers).

--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -1,11 +1,15 @@
 package falcon
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	httpruntime "github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
@@ -89,6 +93,10 @@ func commonHTTPClientConfig(c *http.Client, ac *ApiConfig) *http.Client {
 		UserAgent: ac.UserAgent(),
 	}
 
+	if ac.RetryConfig != nil {
+		c.Transport = &retryTransport{T: c.Transport, config: ac.RetryConfig}
+	}
+
 	if ac.TransportDecorator != nil {
 		c.Transport = ac.TransportDecorator(c.Transport)
 	}
@@ -133,6 +141,85 @@ func (w *workaround) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Add("Content-Type", "application/json")
 	}
 	return w.T.RoundTrip(req)
+}
+
+type retryTransport struct {
+	T      http.RoundTripper
+	config *RetryConfig
+}
+
+func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var resp *http.Response
+
+	operation := func() (*http.Response, error) {
+		cloned, err := cloneRequest(req)
+		if err != nil {
+			return nil, backoff.Permanent(fmt.Errorf("failed to clone request: %w", err))
+		}
+
+		resp, err := rt.T.RoundTrip(cloned)
+		if err != nil {
+			return resp, err
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			log.Debugf("gofalcon: retrying request to %s, status %d", req.URL.Path, resp.StatusCode)
+			drainBody(resp)
+			return nil, fmt.Errorf("retryable HTTP status: %d", resp.StatusCode)
+		}
+
+		return resp, nil
+	}
+
+	b := backoff.NewExponentialBackOff()
+	if rt.config.InitialInterval != 0 {
+		b.InitialInterval = rt.config.InitialInterval
+	} else {
+		b.InitialInterval = 2 * time.Second
+	}
+	if rt.config.MaxInterval != 0 {
+		b.MaxInterval = rt.config.MaxInterval
+	} else {
+		b.MaxInterval = time.Minute
+	}
+
+	opts := []backoff.RetryOption{backoff.WithBackOff(b)}
+	if rt.config.MaxTries > 0 {
+		opts = append(opts, backoff.WithMaxTries(rt.config.MaxTries))
+	}
+
+	resp, err := backoff.Retry(req.Context(), operation, opts...)
+	return resp, err
+}
+
+func cloneRequest(req *http.Request) (*http.Request, error) {
+	cloned := req.Clone(req.Context())
+
+	if req.Body != nil && req.Body != http.NoBody {
+		if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get request body: %w", err)
+			}
+			cloned.Body = body
+		} else {
+			bodyBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read request body: %w", err)
+			}
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			cloned.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+	}
+
+	return cloned, nil
+}
+
+func drainBody(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
 }
 
 // TransportDecorator accepts a RoundTripper and returns a RoundTripper.

--- a/falcon/api_client_test.go
+++ b/falcon/api_client_test.go
@@ -1,0 +1,202 @@
+package falcon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeTransport returns responses from a pre-configured sequence, repeating the
+// last entry once exhausted. It also records the body read on each call.
+type fakeTransport struct {
+	responses []*http.Response
+	errors    []error
+	calls     int
+	bodies    []string
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil && req.Body != http.NoBody {
+		b, _ := io.ReadAll(req.Body)
+		f.bodies = append(f.bodies, string(b))
+	} else {
+		f.bodies = append(f.bodies, "")
+	}
+	i := f.calls
+	if i >= len(f.responses) {
+		i = len(f.responses) - 1
+	}
+	f.calls++
+	return f.responses[i], f.errors[i]
+}
+
+func fakeResp(code int) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}
+}
+
+func fastRetry(maxTries uint) *RetryConfig {
+	return &RetryConfig{
+		MaxTries:        maxTries,
+		InitialInterval: time.Millisecond,
+		MaxInterval:     5 * time.Millisecond,
+	}
+}
+
+func TestRetryTransport(t *testing.T) {
+	tests := map[string]struct {
+		responses  []*http.Response
+		errors     []error
+		wantStatus int
+		wantErr    bool
+		wantCalls  int
+	}{
+		"no retry on 2xx": {
+			responses:  []*http.Response{fakeResp(200)},
+			errors:     []error{nil},
+			wantStatus: 200,
+			wantCalls:  1,
+		},
+		"no retry on 4xx": {
+			responses:  []*http.Response{fakeResp(400)},
+			errors:     []error{nil},
+			wantStatus: 400,
+			wantCalls:  1,
+		},
+		"retries on 429": {
+			responses:  []*http.Response{fakeResp(429), fakeResp(200)},
+			errors:     []error{nil, nil},
+			wantStatus: 200,
+			wantCalls:  2,
+		},
+		"retries on 5xx": {
+			responses:  []*http.Response{fakeResp(503), fakeResp(503), fakeResp(200)},
+			errors:     []error{nil, nil, nil},
+			wantStatus: 200,
+			wantCalls:  3,
+		},
+		"stops after MaxTries": {
+			responses: []*http.Response{fakeResp(503)},
+			errors:    []error{nil},
+			wantErr:   true,
+			wantCalls: 3,
+		},
+		"retries on network error": {
+			responses:  []*http.Response{nil, fakeResp(200)},
+			errors:     []error{errors.New("connection refused"), nil},
+			wantStatus: 200,
+			wantCalls:  2,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeTransport{responses: tc.responses, errors: tc.errors}
+			rt := &retryTransport{T: fake, config: fastRetry(3)}
+
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+			resp, err := rt.RoundTrip(req)
+
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tc.wantErr && resp.StatusCode != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d", tc.wantStatus, resp.StatusCode)
+			}
+			if fake.calls != tc.wantCalls {
+				t.Fatalf("expected %d calls, got %d", tc.wantCalls, fake.calls)
+			}
+		})
+	}
+}
+
+func TestRetryTransport_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeTransport{
+		responses: []*http.Response{nil, nil, nil},
+		errors:    []error{errors.New("err"), errors.New("err"), errors.New("err")},
+	}
+	rt := &retryTransport{
+		T:      &cancelAfterNTransport{wrapped: fake, n: 2, cancel: cancel},
+		config: fastRetry(10),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+}
+
+// TestRetryTransport_UnlimitedRetriesUntilContextCancellation verifies that
+// MaxTries:0 keeps retrying until context cancellation and is not subject to
+// any internal elapsed-time limit imposed by the backoff library.
+func TestRetryTransport_UnlimitedRetriesUntilContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeTransport{
+		responses: []*http.Response{nil, nil, nil, nil, nil},
+		errors:    []error{errors.New("err"), errors.New("err"), errors.New("err"), errors.New("err"), errors.New("err")},
+	}
+	rt := &retryTransport{
+		T:      &cancelAfterNTransport{wrapped: fake, n: 4, cancel: cancel},
+		config: &RetryConfig{MaxTries: 0, InitialInterval: time.Millisecond, MaxInterval: 5 * time.Millisecond},
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if fake.calls < 4 {
+		t.Fatalf("expected at least 4 calls before cancellation, got %d", fake.calls)
+	}
+}
+
+// cancelAfterNTransport cancels the context after n calls.
+type cancelAfterNTransport struct {
+	wrapped http.RoundTripper
+	n       int
+	calls   int
+	cancel  context.CancelFunc
+}
+
+func (c *cancelAfterNTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.calls++
+	if c.calls >= c.n {
+		c.cancel()
+	}
+	return c.wrapped.RoundTrip(req)
+}
+
+func TestRetryTransport_BodyReplayedOnRetry(t *testing.T) {
+	body := "hello falcon"
+	fake := &fakeTransport{
+		responses: []*http.Response{fakeResp(503), fakeResp(200)},
+		errors:    []error{nil, nil},
+	}
+	rt := &retryTransport{T: fake, config: fastRetry(3)}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", bytes.NewBufferString(body))
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", fake.calls)
+	}
+	for i, b := range fake.bodies {
+		if b != body {
+			t.Errorf("call %d: expected body %q, got %q", i, body, b)
+		}
+	}
+}

--- a/falcon/api_config.go
+++ b/falcon/api_config.go
@@ -8,6 +8,17 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client"
 )
 
+// RetryConfig configures automatic retry with exponential backoff for transient errors
+// (network errors, 429, 5xx). Assign to ApiConfig.RetryConfig to enable; nil disables retry.
+type RetryConfig struct {
+	// MaxTries is the maximum total number of attempts (initial + retries). 0 means unlimited.
+	MaxTries uint
+	// InitialInterval is the starting backoff duration. Defaults to 2 seconds if zero.
+	InitialInterval time.Duration
+	// MaxInterval caps the exponential backoff. Defaults to 1 minute if zero.
+	MaxInterval time.Duration
+}
+
 // ApiConfig object is used to initialise and configure API Client. Together with NewClient function, ApiConfig provides preferred way to initiate API communication.
 type ApiConfig struct {
 	// AccessToken is the access token used to access the CrowdStrike Falcon platform.
@@ -34,6 +45,9 @@ type ApiConfig struct {
 	HttpTimeOutOverride *time.Duration
 	// UserAgentOverride allows to override default User-Agent HTTP header when talking with CrowdStrike API (default: gofalcon/$VERSION)
 	UserAgentOverride string
+	// RetryConfig enables automatic retry with exponential backoff for transient errors (network errors, 429, 5xx).
+	// Nil disables retry entirely.
+	RetryConfig *RetryConfig
 	// TransportDecorator allows users to decorate and customize default authenticated client http.RoundTripper behavior.
 	TransportDecorator TransportDecorator
 	// Debug forces print out of all http traffic going through the API Runtime

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/go-openapi/errors v0.22.0
 	github.com/go-openapi/runtime v0.27.1
 	github.com/go-openapi/strfmt v0.22.2

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Adds RetryConfig to ApiConfig enabling automatic retry for transient errors (network errors, 429, 5xx) via cenkalti/backoff/v5. When nil (default), behaviour is unchanged.

Closes #606