### PR TITLE
fix: make api.IndicatorUpdateReqV1 expiration, severity, and source fields nullable

### DIFF
--- a/falcon/models/api_indicator_update_req_v1.go
+++ b/falcon/models/api_indicator_update_req_v1.go
@@ -48,7 +48,7 @@ type APIIndicatorUpdateReqV1 struct {
 	Platforms []string `json:"platforms"`
 
 	// severity
-	Severity string `json:"severity,omitempty"`
+	Severity *string `json:"severity,omitempty"`
 
 	// source
 	Source string `json:"source,omitempty"`

--- a/falcon/models/api_indicator_update_req_v1.go
+++ b/falcon/models/api_indicator_update_req_v1.go
@@ -51,7 +51,7 @@ type APIIndicatorUpdateReqV1 struct {
 	Severity *string `json:"severity,omitempty"`
 
 	// source
-	Source string `json:"source,omitempty"`
+	Source *string `json:"source,omitempty"`
 
 	// tags
 	Tags []string `json:"tags"`

--- a/falcon/models/api_indicator_update_req_v1.go
+++ b/falcon/models/api_indicator_update_req_v1.go
@@ -30,7 +30,7 @@ type APIIndicatorUpdateReqV1 struct {
 
 	// expiration
 	// Format: date-time
-	Expiration strfmt.DateTime `json:"expiration,omitempty"`
+	Expiration *strfmt.DateTime `json:"expiration,omitempty"`
 
 	// host groups
 	HostGroups []string `json:"host_groups"`

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -224,6 +224,9 @@
  | .definitions."api.IndicatorCreateReqV1".properties.expiration += {"x-nullable": true}
  | .definitions."api.IndicatorUpdateReqV1".properties.expiration += {"x-nullable": true}
 
+ # Allow severity to be nullable so callers can reset it
+ | .definitions."api.IndicatorUpdateReqV1".properties.severity += {"x-nullable": true}
+
  # 202 is a valid response for /real-time-response/entities/scripts/v1 patch
 | .paths."/real-time-response/entities/scripts/v1".patch.responses."202" = .paths."/real-time-response/entities/scripts/v1".patch.responses."200"
 | del(.paths."/real-time-response/entities/scripts/v1".patch.responses."200")

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -222,6 +222,7 @@
 
  # Allow expiration to be nullable
  | .definitions."api.IndicatorCreateReqV1".properties.expiration += {"x-nullable": true}
+ | .definitions."api.IndicatorUpdateReqV1".properties.expiration += {"x-nullable": true}
 
  # 202 is a valid response for /real-time-response/entities/scripts/v1 patch
 | .paths."/real-time-response/entities/scripts/v1".patch.responses."202" = .paths."/real-time-response/entities/scripts/v1".patch.responses."200"

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -224,8 +224,9 @@
  | .definitions."api.IndicatorCreateReqV1".properties.expiration += {"x-nullable": true}
  | .definitions."api.IndicatorUpdateReqV1".properties.expiration += {"x-nullable": true}
 
- # Allow severity to be nullable so callers can reset it
+ # Allow severity and source to be nullable so callers can reset them
  | .definitions."api.IndicatorUpdateReqV1".properties.severity += {"x-nullable": true}
+ | .definitions."api.IndicatorUpdateReqV1".properties.source += {"x-nullable": true}
 
  # 202 is a valid response for /real-time-response/entities/scripts/v1 patch
 | .paths."/real-time-response/entities/scripts/v1".patch.responses."202" = .paths."/real-time-response/entities/scripts/v1".patch.responses."200"


### PR DESCRIPTION
Prevents silent clearing of expiration on indicator updates when callers do not set the field explicitly, and allows severity and source to be reset rather than being permanently retained when omitted.

Supports https://github.com/CrowdStrike/terraform-provider-crowdstrike/pull/309.