### PR TITLE
fix: make api.IndicatorUpdateReqV1 description field nullable

### DIFF
--- a/falcon/models/api_indicator_update_req_v1.go
+++ b/falcon/models/api_indicator_update_req_v1.go
@@ -26,7 +26,7 @@ type APIIndicatorUpdateReqV1 struct {
 	AppliedGlobally bool `json:"applied_globally,omitempty"`
 
 	// description
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// expiration
 	// Format: date-time

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -224,7 +224,8 @@
  | .definitions."api.IndicatorCreateReqV1".properties.expiration += {"x-nullable": true}
  | .definitions."api.IndicatorUpdateReqV1".properties.expiration += {"x-nullable": true}
 
- # Allow severity and source to be nullable so callers can reset them
+ # Allow description, severity, and source to be nullable so callers can reset them
+ | .definitions."api.IndicatorUpdateReqV1".properties.description += {"x-nullable": true}
  | .definitions."api.IndicatorUpdateReqV1".properties.severity += {"x-nullable": true}
  | .definitions."api.IndicatorUpdateReqV1".properties.source += {"x-nullable": true}
 


### PR DESCRIPTION
Allows description to be reset rather than being permanently retained when omitted.

Supports https://github.com/CrowdStrike/terraform-provider-crowdstrike/pull/309.