### PR TITLE
feat: improve proactive rate-limit throttling and add pre-flight deadline check

### DIFF
--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -2,12 +2,15 @@ package falcon
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -89,10 +92,12 @@ func clientCredentialsHTTPClient(ac *ApiConfig) *http.Client {
 
 func commonHTTPClientConfig(c *http.Client, ac *ApiConfig) *http.Client {
 	c.Timeout = ac.HttpTimeout()
-	c.Transport = &roundTripper{
+	rt := &roundTripper{
 		T:         &workaround{T: c.Transport},
 		UserAgent: ac.UserAgent(),
 	}
+	rt.remaining.Store(-1)
+	c.Transport = rt
 
 	if ac.RetryConfig != nil {
 		c.Transport = &retryTransport{T: c.Transport, config: ac.RetryConfig}
@@ -105,23 +110,54 @@ func commonHTTPClientConfig(c *http.Client, ac *ApiConfig) *http.Client {
 	return c
 }
 
+const (
+	rateLimitThresholdHigh int64 = 10
+	rateLimitThresholdLow  int64 = 5
+)
+
 type roundTripper struct {
-	T                   http.RoundTripper
-	UserAgent           string
-	LastRateLimitDigits int
+	T         http.RoundTripper
+	UserAgent string
+	remaining atomic.Int64
+}
+
+func (rt *roundTripper) proactiveDelay() time.Duration {
+	remaining := rt.remaining.Load()
+	switch {
+	case remaining < 0:
+		return 0
+	case remaining <= rateLimitThresholdLow:
+		return 500 * time.Millisecond
+	case remaining <= rateLimitThresholdHigh:
+		return 200 * time.Millisecond
+	default:
+		return 0
+	}
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Add("User-Agent", rt.UserAgent)
 	req.Header.Add("CrowdStrike-SDK", "crowdstrike-gofalcon/"+Version.String())
 
-	if rt.LastRateLimitDigits == 1 || rt.LastRateLimitDigits == 2 {
-		log.Debug("Approaching CrowdStrike API rate limits. Waiting 500 millisecond.")
-		time.Sleep(500 * time.Millisecond)
+	if delay := rt.proactiveDelay(); delay > 0 {
+		log.Debugf("Approaching CrowdStrike API rate limits (remaining=%d). Waiting %s.",
+			rt.remaining.Load(), delay)
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, req.Context().Err()
+		}
 	}
+
 	response, err := rt.T.RoundTrip(req)
 	if response != nil {
-		rt.LastRateLimitDigits = len(response.Header.Get("X-Ratelimit-Remaining"))
+		if s := response.Header.Get("X-Ratelimit-Remaining"); s != "" {
+			if v, parseErr := strconv.ParseInt(s, 10, 64); parseErr == nil {
+				rt.remaining.Store(v)
+			}
+		}
 	}
 
 	return response, err
@@ -147,6 +183,9 @@ func (w *workaround) RoundTrip(req *http.Request) (*http.Response, error) {
 type retryTransport struct {
 	T      http.RoundTripper
 	config *RetryConfig
+
+	mu            sync.Mutex
+	cooldownUntil time.Time
 }
 
 func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -165,6 +204,10 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	operation := func() (*http.Response, error) {
+		if err := rt.waitForCooldown(req.Context()); err != nil {
+			return nil, backoff.Permanent(err)
+		}
+
 		cloned, err := cloneRequest(req)
 		if err != nil {
 			return nil, backoff.Permanent(fmt.Errorf("failed to clone request: %w", err))
@@ -178,6 +221,7 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if resp.StatusCode == http.StatusTooManyRequests {
 			if wait := parseRetryAfter(resp.Header.Get("X-RateLimit-RetryAfter")); wait > 0 {
 				bo.override = wait
+				rt.setCooldown(wait)
 			}
 			log.Debugf("rate limited on %s, retrying", req.URL.Path)
 			drainBody(resp)
@@ -200,6 +244,46 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	resp, err := backoff.Retry(req.Context(), operation, opts...)
 	return resp, err
+}
+
+// setCooldown updates the shared cooldown timestamp so subsequent requests
+// wait before sending.
+func (rt *retryTransport) setCooldown(d time.Duration) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	until := time.Now().Add(d)
+	if until.After(rt.cooldownUntil) {
+		rt.cooldownUntil = until
+	}
+}
+
+// waitForCooldown blocks until the shared rate-limit cooldown expires or the
+// context is cancelled.
+func (rt *retryTransport) waitForCooldown(ctx context.Context) error {
+	rt.mu.Lock()
+	until := rt.cooldownUntil
+	rt.mu.Unlock()
+
+	wait := time.Until(until)
+	if wait <= 0 {
+		return nil
+	}
+
+	if deadline, ok := ctx.Deadline(); ok && deadline.Before(until) {
+		return fmt.Errorf("rate-limit cooldown (%s) exceeds context deadline: %w",
+			wait.Round(time.Millisecond), context.DeadlineExceeded)
+	}
+
+	log.Debugf("waiting %s for rate-limit cooldown before sending request", wait.Round(time.Millisecond))
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func cloneRequest(req *http.Request) (*http.Request, error) {

--- a/falcon/api_client_test.go
+++ b/falcon/api_client_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -343,5 +345,250 @@ func TestRetryTransport_5xxDoesNotUseRetryAfter(t *testing.T) {
 	}
 	if elapsed > 5*time.Second {
 		t.Fatalf("5xx should use exponential backoff, not retry-after; elapsed %v", elapsed)
+	}
+}
+
+func TestRetryTransport_SharedCooldownGatesSubsequentRequests(t *testing.T) {
+	fake := &fakeTransport{
+		responses: []*http.Response{fakeResp(200), fakeResp(200)},
+		errors:    []error{nil, nil},
+	}
+	rt := &retryTransport{T: fake, config: fastRetry(3)}
+
+	rt.setCooldown(500 * time.Millisecond)
+
+	rt.mu.Lock()
+	cooldownSet := !rt.cooldownUntil.IsZero()
+	rt.mu.Unlock()
+
+	if !cooldownSet {
+		t.Fatal("expected cooldownUntil to be set after setCooldown")
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/gated", nil)
+	resp, err := rt.RoundTrip(req)
+	waited := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if waited < 400*time.Millisecond {
+		t.Fatalf("expected request to be gated by cooldown, but only waited %v", waited)
+	}
+}
+
+func TestRetryTransport_SharedCooldownConcurrentRequests(t *testing.T) {
+	transport := &funcTransport{fn: func(req *http.Request) (*http.Response, error) {
+		return fakeResp(200), nil
+	}}
+	rt := &retryTransport{T: transport, config: fastRetry(5)}
+
+	rt.setCooldown(500 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	var gatedCount atomic.Int32
+
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/gated", nil)
+			resp, err := rt.RoundTrip(req)
+			elapsed := time.Since(start)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if resp.StatusCode != 200 {
+				t.Errorf("expected 200, got %d", resp.StatusCode)
+				return
+			}
+			if elapsed >= 400*time.Millisecond {
+				gatedCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if gatedCount.Load() == 0 {
+		t.Fatal("expected at least one concurrent request to be gated by cooldown")
+	}
+}
+
+func TestRetryTransport_CooldownRespectsContextCancellation(t *testing.T) {
+	rt := &retryTransport{
+		T:      &fakeTransport{responses: []*http.Response{fakeResp(200)}, errors: []error{nil}},
+		config: fastRetry(3),
+	}
+
+	rt.mu.Lock()
+	rt.cooldownUntil = time.Now().Add(10 * time.Second)
+	rt.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+}
+
+// funcTransport is a test helper that calls a function for each RoundTrip.
+type funcTransport struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (f *funcTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f.fn(req)
+}
+
+func fakeRespWithRemaining(code int, remaining string) *http.Response {
+	r := fakeResp(code)
+	r.Header.Set("X-Ratelimit-Remaining", remaining)
+	return r
+}
+
+func TestRoundTripper_ProactiveThrottle_NoDelay(t *testing.T) {
+	t.Parallel()
+	fake := &fakeTransport{
+		responses: []*http.Response{fakeRespWithRemaining(200, "50"), fakeRespWithRemaining(200, "49")},
+		errors:    []error{nil, nil},
+	}
+	rt := &roundTripper{T: fake, UserAgent: "test"}
+	rt.remaining.Store(-1)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	start := time.Now()
+	_, _ = rt.RoundTrip(req)
+	if time.Since(start) > 50*time.Millisecond {
+		t.Fatal("unexpected delay on first request with unknown remaining")
+	}
+
+	req2, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	start = time.Now()
+	_, _ = rt.RoundTrip(req2)
+	if time.Since(start) > 50*time.Millisecond {
+		t.Fatal("unexpected delay when remaining=50")
+	}
+}
+
+func TestRoundTripper_ProactiveThrottle_ModerateDelay(t *testing.T) {
+	t.Parallel()
+	fake := &fakeTransport{
+		responses: []*http.Response{fakeRespWithRemaining(200, "7")},
+		errors:    []error{nil},
+	}
+	rt := &roundTripper{T: fake, UserAgent: "test"}
+	rt.remaining.Store(8)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	start := time.Now()
+	_, _ = rt.RoundTrip(req)
+	elapsed := time.Since(start)
+	if elapsed < 150*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("expected ~200ms delay, got %v", elapsed)
+	}
+}
+
+func TestRoundTripper_ProactiveThrottle_StrongDelay(t *testing.T) {
+	t.Parallel()
+	fake := &fakeTransport{
+		responses: []*http.Response{fakeRespWithRemaining(200, "2")},
+		errors:    []error{nil},
+	}
+	rt := &roundTripper{T: fake, UserAgent: "test"}
+	rt.remaining.Store(3)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	start := time.Now()
+	_, _ = rt.RoundTrip(req)
+	elapsed := time.Since(start)
+	if elapsed < 400*time.Millisecond || elapsed > 750*time.Millisecond {
+		t.Fatalf("expected ~500ms delay, got %v", elapsed)
+	}
+}
+
+func TestRoundTripper_ProactiveThrottle_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	fake := &fakeTransport{
+		responses: []*http.Response{fakeResp(200)},
+		errors:    []error{nil},
+	}
+	rt := &roundTripper{T: fake, UserAgent: "test"}
+	rt.remaining.Store(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	start := time.Now()
+	_, err := rt.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("expected prompt cancellation, but waited %v", elapsed)
+	}
+}
+
+func TestRoundTripper_ProactiveThrottle_UnparseableHeader(t *testing.T) {
+	t.Parallel()
+	fake := &fakeTransport{
+		responses: []*http.Response{fakeRespWithRemaining(200, "abc")},
+		errors:    []error{nil},
+	}
+	rt := &roundTripper{T: fake, UserAgent: "test"}
+	rt.remaining.Store(-1)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	start := time.Now()
+	_, _ = rt.RoundTrip(req)
+	if time.Since(start) > 50*time.Millisecond {
+		t.Fatal("unexpected delay with unparseable header")
+	}
+	if rt.remaining.Load() != -1 {
+		t.Fatalf("expected remaining to stay -1, got %d", rt.remaining.Load())
+	}
+}
+
+func TestWaitForCooldown_PreflightDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+	rt := &retryTransport{
+		T:      &fakeTransport{responses: []*http.Response{fakeResp(200)}, errors: []error{nil}},
+		config: fastRetry(3),
+	}
+	rt.mu.Lock()
+	rt.cooldownUntil = time.Now().Add(10 * time.Second)
+	rt.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := rt.waitForCooldown(ctx)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if elapsed > 10*time.Millisecond {
+		t.Fatalf("expected immediate return from preflight check, but waited %v", elapsed)
+	}
+	if !strings.Contains(err.Error(), "exceeds context deadline") {
+		t.Fatalf("expected descriptive error message, got: %v", err)
 	}
 }


### PR DESCRIPTION
Replace the crude LastRateLimitDigits heuristic with proper X-Ratelimit-Remaining integer tracking and two-tier progressive delays (200ms/500ms). The proactive wait is now context-cancellation-aware. Additionally, waitForCooldown now fails fast when the cooldown duration would exceed the context deadline.