### PR TITLE
fix(models): correct serverless SARIF resources to a single object

### DIFF
--- a/falcon/models/vulnerabilities_vulnerability_entity_s_a_r_i_f_response.go
+++ b/falcon/models/vulnerabilities_vulnerability_entity_s_a_r_i_f_response.go
@@ -29,7 +29,7 @@ type VulnerabilitiesVulnerabilityEntitySARIFResponse struct {
 
 	// resources
 	// Required: true
-	Resources []*ModelsVulnerabilitySARIF `json:"resources"`
+	Resources *ModelsVulnerabilitySARIF `json:"resources"`
 }
 
 // Validate validates this vulnerabilities vulnerability entity s a r i f response
@@ -106,22 +106,15 @@ func (m *VulnerabilitiesVulnerabilityEntitySARIFResponse) validateResources(form
 		return err
 	}
 
-	for i := 0; i < len(m.Resources); i++ {
-		if swag.IsZero(m.Resources[i]) { // not required
-			continue
-		}
-
-		if m.Resources[i] != nil {
-			if err := m.Resources[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce.ValidateName("resources" + "." + strconv.Itoa(i))
-				}
-				return err
+	if m.Resources != nil {
+		if err := m.Resources.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("resources")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("resources")
 			}
+			return err
 		}
-
 	}
 
 	return nil
@@ -193,24 +186,16 @@ func (m *VulnerabilitiesVulnerabilityEntitySARIFResponse) contextValidateMeta(ct
 
 func (m *VulnerabilitiesVulnerabilityEntitySARIFResponse) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
-	for i := 0; i < len(m.Resources); i++ {
+	if m.Resources != nil {
 
-		if m.Resources[i] != nil {
-
-			if swag.IsZero(m.Resources[i]) { // not required
-				return nil
+		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("resources")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("resources")
 			}
-
-			if err := m.Resources[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce.ValidateName("resources" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
+			return err
 		}
-
 	}
 
 	return nil

--- a/falcon/version.go
+++ b/falcon/version.go
@@ -4,4 +4,4 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-var Version = semver.MustParse("0.21.0")
+var Version = semver.MustParse("0.21.1")

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -801,3 +801,9 @@
       "x-www-form-urlencoded": {"type": "object"}
     }
   }
+
+# The serverless SARIF combined endpoint (GET /lambdas/combined/vulnerabilities/sarif/v1)
+# returns "resources" as a single SARIF object ({$schema, version, runs}), but the spec
+# declares it as an array. Correct it to a single object so the generated model can decode
+# a real response (an array type fails to unmarshal the object the API returns).
+| .definitions."vulnerabilities.VulnerabilityEntitySARIFResponse".properties.resources = {"$ref": "#/definitions/models.VulnerabilitySARIF"}


### PR DESCRIPTION
The swagger spec declares the `resources` field of `vulnerabilities.VulnerabilityEntitySARIFResponse` as an array of SARIF documents, but the live API for `GET /lambdas/combined/vulnerabilities/sarif/v1` returns `resources` as a single SARIF object (`{$schema, version, runs}`). Any non-empty response fails to unmarshal into the array-typed model:

```
json: cannot unmarshal object into Go struct field VulnerabilitiesVulnerabilityEntitySARIFResponse.resources of type []*models.ModelsVulnerabilitySARIF
```

Empty results decode fine (missing/null `resources` → nil slice), which masks the defect until a tenant actually has serverless vulnerability data. FalconPy and the Python falcon-mcp module both treat `resources` as a single object (`response["resources"]["runs"]`), so gofalcon was the outlier here.

This patches `vulnerabilities.VulnerabilityEntitySARIFResponse` in `specs/transformation.jq` to redefine `resources` as a single `$ref` to `models.VulnerabilitySARIF`, regenerates the model (the field becomes `*ModelsVulnerabilitySARIF`), and bumps the version to 0.21.1. This is the same class of interim spec fix already applied in `transformation.jq`; the underlying swagger defect should also be reported upstream so the published spec is corrected.