### PR TITLE
fix(ml_exclusions): decode ML v2 exclusions responses into typed resources

### DIFF
--- a/falcon/client/ml_exclusions/exclusions_create_v2_responses.go
+++ b/falcon/client/ml_exclusions/exclusions_create_v2_responses.go
@@ -77,6 +77,8 @@ type ExclusionsCreateV2OK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload *models.ExclusionsRespV1
 }
 
 // IsSuccess returns true when this exclusions create v2 o k response has a 2xx status code
@@ -110,11 +112,15 @@ func (o *ExclusionsCreateV2OK) Code() int {
 }
 
 func (o *ExclusionsCreateV2OK) Error() string {
-	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2OK ", 200)
+	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2OK  %+v", 200, o.Payload)
 }
 
 func (o *ExclusionsCreateV2OK) String() string {
-	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2OK ", 200)
+	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2OK  %+v", 200, o.Payload)
+}
+
+func (o *ExclusionsCreateV2OK) GetPayload() *models.ExclusionsRespV1 {
+	return o.Payload
 }
 
 func (o *ExclusionsCreateV2OK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -146,6 +152,13 @@ func (o *ExclusionsCreateV2OK) readResponse(response runtime.ClientResponse, con
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	o.Payload = new(models.ExclusionsRespV1)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/falcon/client/ml_exclusions/exclusions_delete_v2_responses.go
+++ b/falcon/client/ml_exclusions/exclusions_delete_v2_responses.go
@@ -77,6 +77,8 @@ type ExclusionsDeleteV2OK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload *models.MsaspecQueryResponse
 }
 
 // IsSuccess returns true when this exclusions delete v2 o k response has a 2xx status code
@@ -110,11 +112,15 @@ func (o *ExclusionsDeleteV2OK) Code() int {
 }
 
 func (o *ExclusionsDeleteV2OK) Error() string {
-	return fmt.Sprintf("[DELETE /exclusions/entities/exclusions/v2][%d] exclusionsDeleteV2OK ", 200)
+	return fmt.Sprintf("[DELETE /exclusions/entities/exclusions/v2][%d] exclusionsDeleteV2OK  %+v", 200, o.Payload)
 }
 
 func (o *ExclusionsDeleteV2OK) String() string {
-	return fmt.Sprintf("[DELETE /exclusions/entities/exclusions/v2][%d] exclusionsDeleteV2OK ", 200)
+	return fmt.Sprintf("[DELETE /exclusions/entities/exclusions/v2][%d] exclusionsDeleteV2OK  %+v", 200, o.Payload)
+}
+
+func (o *ExclusionsDeleteV2OK) GetPayload() *models.MsaspecQueryResponse {
+	return o.Payload
 }
 
 func (o *ExclusionsDeleteV2OK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -146,6 +152,13 @@ func (o *ExclusionsDeleteV2OK) readResponse(response runtime.ClientResponse, con
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	o.Payload = new(models.MsaspecQueryResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/falcon/client/ml_exclusions/exclusions_get_v2_responses.go
+++ b/falcon/client/ml_exclusions/exclusions_get_v2_responses.go
@@ -77,6 +77,8 @@ type ExclusionsGetV2OK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload *models.ExclusionsRespV1
 }
 
 // IsSuccess returns true when this exclusions get v2 o k response has a 2xx status code
@@ -110,11 +112,15 @@ func (o *ExclusionsGetV2OK) Code() int {
 }
 
 func (o *ExclusionsGetV2OK) Error() string {
-	return fmt.Sprintf("[GET /exclusions/entities/exclusions/v2][%d] exclusionsGetV2OK ", 200)
+	return fmt.Sprintf("[GET /exclusions/entities/exclusions/v2][%d] exclusionsGetV2OK  %+v", 200, o.Payload)
 }
 
 func (o *ExclusionsGetV2OK) String() string {
-	return fmt.Sprintf("[GET /exclusions/entities/exclusions/v2][%d] exclusionsGetV2OK ", 200)
+	return fmt.Sprintf("[GET /exclusions/entities/exclusions/v2][%d] exclusionsGetV2OK  %+v", 200, o.Payload)
+}
+
+func (o *ExclusionsGetV2OK) GetPayload() *models.ExclusionsRespV1 {
+	return o.Payload
 }
 
 func (o *ExclusionsGetV2OK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -146,6 +152,13 @@ func (o *ExclusionsGetV2OK) readResponse(response runtime.ClientResponse, consum
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	o.Payload = new(models.ExclusionsRespV1)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/falcon/client/ml_exclusions/exclusions_search_v2_responses.go
+++ b/falcon/client/ml_exclusions/exclusions_search_v2_responses.go
@@ -77,6 +77,8 @@ type ExclusionsSearchV2OK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload *models.MsaspecQueryResponse
 }
 
 // IsSuccess returns true when this exclusions search v2 o k response has a 2xx status code
@@ -110,11 +112,15 @@ func (o *ExclusionsSearchV2OK) Code() int {
 }
 
 func (o *ExclusionsSearchV2OK) Error() string {
-	return fmt.Sprintf("[GET /exclusions/queries/exclusions/v2][%d] exclusionsSearchV2OK ", 200)
+	return fmt.Sprintf("[GET /exclusions/queries/exclusions/v2][%d] exclusionsSearchV2OK  %+v", 200, o.Payload)
 }
 
 func (o *ExclusionsSearchV2OK) String() string {
-	return fmt.Sprintf("[GET /exclusions/queries/exclusions/v2][%d] exclusionsSearchV2OK ", 200)
+	return fmt.Sprintf("[GET /exclusions/queries/exclusions/v2][%d] exclusionsSearchV2OK  %+v", 200, o.Payload)
+}
+
+func (o *ExclusionsSearchV2OK) GetPayload() *models.MsaspecQueryResponse {
+	return o.Payload
 }
 
 func (o *ExclusionsSearchV2OK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -146,6 +152,13 @@ func (o *ExclusionsSearchV2OK) readResponse(response runtime.ClientResponse, con
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	o.Payload = new(models.MsaspecQueryResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/falcon/client/ml_exclusions/exclusions_update_v2_responses.go
+++ b/falcon/client/ml_exclusions/exclusions_update_v2_responses.go
@@ -77,6 +77,8 @@ type ExclusionsUpdateV2OK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload *models.ExclusionsRespV1
 }
 
 // IsSuccess returns true when this exclusions update v2 o k response has a 2xx status code
@@ -110,11 +112,15 @@ func (o *ExclusionsUpdateV2OK) Code() int {
 }
 
 func (o *ExclusionsUpdateV2OK) Error() string {
-	return fmt.Sprintf("[PATCH /exclusions/entities/exclusions/v2][%d] exclusionsUpdateV2OK ", 200)
+	return fmt.Sprintf("[PATCH /exclusions/entities/exclusions/v2][%d] exclusionsUpdateV2OK  %+v", 200, o.Payload)
 }
 
 func (o *ExclusionsUpdateV2OK) String() string {
-	return fmt.Sprintf("[PATCH /exclusions/entities/exclusions/v2][%d] exclusionsUpdateV2OK ", 200)
+	return fmt.Sprintf("[PATCH /exclusions/entities/exclusions/v2][%d] exclusionsUpdateV2OK  %+v", 200, o.Payload)
+}
+
+func (o *ExclusionsUpdateV2OK) GetPayload() *models.ExclusionsRespV1 {
+	return o.Payload
 }
 
 func (o *ExclusionsUpdateV2OK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -146,6 +152,13 @@ func (o *ExclusionsUpdateV2OK) readResponse(response runtime.ClientResponse, con
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	o.Payload = new(models.ExclusionsRespV1)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -807,3 +807,15 @@
 # declares it as an array. Correct it to a single object so the generated model can decode
 # a real response (an array type fails to unmarshal the object the API returns).
 | .definitions."vulnerabilities.VulnerabilityEntitySARIFResponse".properties.resources = {"$ref": "#/definitions/models.VulnerabilitySARIF"}
+
+# The ML (machine-learning) exclusions v2 operations declare an empty {} 200 response
+# schema, so go-swagger falls back to msa.ReplyMetaOnly and silently drops every resource
+# the API returns. The record shape matches the existing v1 definitions, so point the 200
+# schemas at the same $refs the ML v1 operations already use (query/delete -> IDs,
+# get/create/update -> full records). Runs before the msaspec.* -> msa.* rename walk, so
+# msaspec.QueryResponse here matches how the IOA v2 search 200 is declared in the raw spec.
+| .paths."/exclusions/queries/exclusions/v2"."get"."responses"."200"."schema"    = {"$ref": "#/definitions/msaspec.QueryResponse"}
+| .paths."/exclusions/entities/exclusions/v2"."get"."responses"."200"."schema"   = {"$ref": "#/definitions/exclusions.RespV1"}
+| .paths."/exclusions/entities/exclusions/v2"."post"."responses"."200"."schema"  = {"$ref": "#/definitions/exclusions.RespV1"}
+| .paths."/exclusions/entities/exclusions/v2"."patch"."responses"."200"."schema" = {"$ref": "#/definitions/exclusions.RespV1"}
+| .paths."/exclusions/entities/exclusions/v2"."delete"."responses"."200"."schema"= {"$ref": "#/definitions/msaspec.QueryResponse"}


### PR DESCRIPTION
The five ML exclusions v2 operations declared an empty 200 response schema in swagger.json, so go-swagger fell back to `msa.ReplyMetaOnly` and silently dropped every ID and record the API returned. IOA v2 works because those operations carry proper `$ref` 200 schemas; ML v2 never had them.

This adds a `transformation.jq` stanza pointing each 200 schema at the definitions the ML v1 operations already use. Search and delete return ID lists (`msaspec.QueryResponse`); get, create, and update return full records (`exclusions.RespV1`). No new definitions were needed.

I regenerated only the five affected response files rather than running a full `clean-generate`, because the local swagger snapshot has drifted well past the committed SDK and a full regen pulls in a large unrelated diff.

Checked it against a live tenant: `ExclusionsSearchV2` now comes back with a populated `Payload.Resources`, and `ExclusionsGetV2` decodes the record's `Value` field.