### PR TITLE
fix(ml_exclusions): add applied_globally and is_descendant_process to v2 request models

### DIFF
--- a/falcon/models/domain_exclusion_create_req_v2.go
+++ b/falcon/models/domain_exclusion_create_req_v2.go
@@ -17,6 +17,9 @@ import (
 // swagger:model domain.ExclusionCreateReqV2
 type DomainExclusionCreateReqV2 struct {
 
+	// applied globally
+	AppliedGlobally bool `json:"applied_globally,omitempty"`
+
 	// comment
 	Comment string `json:"comment,omitempty"`
 
@@ -28,6 +31,9 @@ type DomainExclusionCreateReqV2 struct {
 
 	// groups
 	Groups []string `json:"groups"`
+
+	// is descendant process
+	IsDescendantProcess bool `json:"is_descendant_process,omitempty"`
 
 	// parent value
 	ParentValue string `json:"parent_value,omitempty"`

--- a/falcon/models/domain_exclusion_update_req_v2.go
+++ b/falcon/models/domain_exclusion_update_req_v2.go
@@ -19,6 +19,9 @@ import (
 // swagger:model domain.ExclusionUpdateReqV2
 type DomainExclusionUpdateReqV2 struct {
 
+	// applied globally
+	AppliedGlobally bool `json:"applied_globally,omitempty"`
+
 	// comment
 	Comment string `json:"comment,omitempty"`
 
@@ -34,6 +37,9 @@ type DomainExclusionUpdateReqV2 struct {
 	// id
 	// Required: true
 	ID *string `json:"id"`
+
+	// is descendant process
+	IsDescendantProcess bool `json:"is_descendant_process,omitempty"`
 
 	// parent value
 	ParentValue string `json:"parent_value,omitempty"`

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -819,3 +819,13 @@
 | .paths."/exclusions/entities/exclusions/v2"."post"."responses"."200"."schema"  = {"$ref": "#/definitions/exclusions.RespV1"}
 | .paths."/exclusions/entities/exclusions/v2"."patch"."responses"."200"."schema" = {"$ref": "#/definitions/exclusions.RespV1"}
 | .paths."/exclusions/entities/exclusions/v2"."delete"."responses"."200"."schema"= {"$ref": "#/definitions/msaspec.QueryResponse"}
+
+# The ML (machine-learning) exclusions v2 create/update request bodies accept applied_globally
+# and is_descendant_process, but the spec omits both from the request definitions. Add them as
+# optional booleans (verified accepted on live create/update) so callers can set them, matching
+# the shapes already used by sv_exclusions.UpdateReqV1.is_descendant_process and
+# api.CertBasedExclusionCreateReqV1.applied_globally.
+| .definitions."domain.ExclusionCreateReqV2".properties.applied_globally = {"type": "boolean"}
+| .definitions."domain.ExclusionCreateReqV2".properties.is_descendant_process = {"type": "boolean"}
+| .definitions."domain.ExclusionUpdateReqV2".properties.applied_globally = {"type": "boolean"}
+| .definitions."domain.ExclusionUpdateReqV2".properties.is_descendant_process = {"type": "boolean"}


### PR DESCRIPTION
The ML exclusions v2 create and update endpoints accept `applied_globally` and `is_descendant_process` in the request body, but the spec leaves both out of the request definitions, so the generated `DomainExclusionCreateReqV2` and `DomainExclusionUpdateReqV2` models had no way to set them.

This adds both as optional booleans through `transformation.jq` and regenerates the two affected models. The field shapes match what's already used for `sv_exclusions.UpdateReqV1.is_descendant_process` and `api.CertBasedExclusionCreateReqV1.applied_globally`.

I checked both fields against the live v2 API before committing. A create with both set returns 201, and a follow-up patch returns 200; neither call rejects the fields. One quirk worth noting: `applied_globally` reads back as `false` when host groups are set, since the service treats globally-applied and group-scoped exclusions as mutually exclusive. The write is still accepted.