### PR TITLE
fix(intel): decode MITRE report downloads into an io.Writer payload

### DIFF
--- a/falcon/client/intel/get_malware_mitre_report_responses.go
+++ b/falcon/client/intel/get_malware_mitre_report_responses.go
@@ -20,13 +20,14 @@ import (
 // GetMalwareMitreReportReader is a Reader for the GetMalwareMitreReport structure.
 type GetMalwareMitreReportReader struct {
 	formats strfmt.Registry
+	writer  io.Writer
 }
 
 // ReadResponse reads a server response into the received o.
 func (o *GetMalwareMitreReportReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 	case 200:
-		result := NewGetMalwareMitreReportOK()
+		result := NewGetMalwareMitreReportOK(o.writer)
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -55,8 +56,11 @@ func (o *GetMalwareMitreReportReader) ReadResponse(response runtime.ClientRespon
 }
 
 // NewGetMalwareMitreReportOK creates a GetMalwareMitreReportOK with default headers values
-func NewGetMalwareMitreReportOK() *GetMalwareMitreReportOK {
-	return &GetMalwareMitreReportOK{}
+func NewGetMalwareMitreReportOK(writer io.Writer) *GetMalwareMitreReportOK {
+	return &GetMalwareMitreReportOK{
+
+		Payload: writer,
+	}
 }
 
 /*
@@ -77,6 +81,8 @@ type GetMalwareMitreReportOK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload io.Writer
 }
 
 // IsSuccess returns true when this get malware mitre report o k response has a 2xx status code
@@ -110,11 +116,15 @@ func (o *GetMalwareMitreReportOK) Code() int {
 }
 
 func (o *GetMalwareMitreReportOK) Error() string {
-	return fmt.Sprintf("[GET /intel/entities/malware-mitre-reports/v1][%d] getMalwareMitreReportOK ", 200)
+	return fmt.Sprintf("[GET /intel/entities/malware-mitre-reports/v1][%d] getMalwareMitreReportOK  %+v", 200, o.Payload)
 }
 
 func (o *GetMalwareMitreReportOK) String() string {
-	return fmt.Sprintf("[GET /intel/entities/malware-mitre-reports/v1][%d] getMalwareMitreReportOK ", 200)
+	return fmt.Sprintf("[GET /intel/entities/malware-mitre-reports/v1][%d] getMalwareMitreReportOK  %+v", 200, o.Payload)
+}
+
+func (o *GetMalwareMitreReportOK) GetPayload() io.Writer {
+	return o.Payload
 }
 
 func (o *GetMalwareMitreReportOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -146,6 +156,11 @@ func (o *GetMalwareMitreReportOK) readResponse(response runtime.ClientResponse, 
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/falcon/client/intel/get_mitre_report_responses.go
+++ b/falcon/client/intel/get_mitre_report_responses.go
@@ -20,13 +20,14 @@ import (
 // GetMitreReportReader is a Reader for the GetMitreReport structure.
 type GetMitreReportReader struct {
 	formats strfmt.Registry
+	writer  io.Writer
 }
 
 // ReadResponse reads a server response into the received o.
 func (o *GetMitreReportReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 	case 200:
-		result := NewGetMitreReportOK()
+		result := NewGetMitreReportOK(o.writer)
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -55,8 +56,11 @@ func (o *GetMitreReportReader) ReadResponse(response runtime.ClientResponse, con
 }
 
 // NewGetMitreReportOK creates a GetMitreReportOK with default headers values
-func NewGetMitreReportOK() *GetMitreReportOK {
-	return &GetMitreReportOK{}
+func NewGetMitreReportOK(writer io.Writer) *GetMitreReportOK {
+	return &GetMitreReportOK{
+
+		Payload: writer,
+	}
 }
 
 /*
@@ -77,6 +81,8 @@ type GetMitreReportOK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload io.Writer
 }
 
 // IsSuccess returns true when this get mitre report o k response has a 2xx status code
@@ -110,11 +116,15 @@ func (o *GetMitreReportOK) Code() int {
 }
 
 func (o *GetMitreReportOK) Error() string {
-	return fmt.Sprintf("[GET /intel/entities/mitre-reports/v1][%d] getMitreReportOK ", 200)
+	return fmt.Sprintf("[GET /intel/entities/mitre-reports/v1][%d] getMitreReportOK  %+v", 200, o.Payload)
 }
 
 func (o *GetMitreReportOK) String() string {
-	return fmt.Sprintf("[GET /intel/entities/mitre-reports/v1][%d] getMitreReportOK ", 200)
+	return fmt.Sprintf("[GET /intel/entities/mitre-reports/v1][%d] getMitreReportOK  %+v", 200, o.Payload)
+}
+
+func (o *GetMitreReportOK) GetPayload() io.Writer {
+	return o.Payload
 }
 
 func (o *GetMitreReportOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -146,6 +156,11 @@ func (o *GetMitreReportOK) readResponse(response runtime.ClientResponse, consume
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/falcon/client/intel/intel_client.go
+++ b/falcon/client/intel/intel_client.go
@@ -47,9 +47,9 @@ type ClientService interface {
 
 	GetMalwareEntities(params *GetMalwareEntitiesParams, opts ...ClientOption) (*GetMalwareEntitiesOK, error)
 
-	GetMalwareMitreReport(params *GetMalwareMitreReportParams, opts ...ClientOption) (*GetMalwareMitreReportOK, error)
+	GetMalwareMitreReport(params *GetMalwareMitreReportParams, writer io.Writer, opts ...ClientOption) (*GetMalwareMitreReportOK, error)
 
-	GetMitreReport(params *GetMitreReportParams, opts ...ClientOption) (*GetMitreReportOK, error)
+	GetMitreReport(params *GetMitreReportParams, writer io.Writer, opts ...ClientOption) (*GetMitreReportOK, error)
 
 	GetVulnerabilities(params *GetVulnerabilitiesParams, opts ...ClientOption) (*GetVulnerabilitiesOK, error)
 
@@ -395,7 +395,7 @@ func (a *Client) GetMalwareEntities(params *GetMalwareEntitiesParams, opts ...Cl
 /*
 GetMalwareMitreReport exports mitre a t t and c k information for a given malware family
 */
-func (a *Client) GetMalwareMitreReport(params *GetMalwareMitreReportParams, opts ...ClientOption) (*GetMalwareMitreReportOK, error) {
+func (a *Client) GetMalwareMitreReport(params *GetMalwareMitreReportParams, writer io.Writer, opts ...ClientOption) (*GetMalwareMitreReportOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetMalwareMitreReportParams()
@@ -408,7 +408,7 @@ func (a *Client) GetMalwareMitreReport(params *GetMalwareMitreReportParams, opts
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
 		Params:             params,
-		Reader:             &GetMalwareMitreReportReader{formats: a.formats},
+		Reader:             &GetMalwareMitreReportReader{formats: a.formats, writer: writer},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
 	}
@@ -433,7 +433,7 @@ func (a *Client) GetMalwareMitreReport(params *GetMalwareMitreReportParams, opts
 /*
 GetMitreReport exports mitre a t t and c k information for a given actor
 */
-func (a *Client) GetMitreReport(params *GetMitreReportParams, opts ...ClientOption) (*GetMitreReportOK, error) {
+func (a *Client) GetMitreReport(params *GetMitreReportParams, writer io.Writer, opts ...ClientOption) (*GetMitreReportOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetMitreReportParams()
@@ -446,7 +446,7 @@ func (a *Client) GetMitreReport(params *GetMitreReportParams, opts ...ClientOpti
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
 		Params:             params,
-		Reader:             &GetMitreReportReader{formats: a.formats},
+		Reader:             &GetMitreReportReader{formats: a.formats, writer: writer},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
 	}

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -7,6 +7,8 @@
   | .paths."/intel/entities/report-files/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   | .paths."/intel/entities/rules-latest-files/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   | .paths."/intel/entities/rules-files/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
+  | .paths."/intel/entities/mitre-reports/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
+  | .paths."/intel/entities/malware-mitre-reports/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   | .paths."/real-time-response/entities/extracted-file-contents/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   # Fix overflow on json number (more than 63 bits are needed hold this field)
   | .definitions."domain.APIEvaluationLogicItemV1".properties.id."x-go-type"={type: "Number", import: {package: "encoding/json"}, hints: {noValidation: true}}


### PR DESCRIPTION
The MITRE report export endpoints return a downloadable file rather than a JSON envelope:

- `GET /intel/entities/mitre-reports/v1` (`GetMitreReport`) — MITRE ATT&CK mapping for an actor
- `GET /intel/entities/malware-mitre-reports/v1` (`GetMalwareMitreReport`) — same for a malware family

The response is served with `Content-Type: application/octet-stream` and `Content-Disposition: attachment`, and the body is a JSON array (or CSV, depending on the `format` param) of the tactic/technique mapping.

The source swagger declares the 200 response with headers only and no schema, so go-swagger generated a body-less `...OK` struct — the reader hydrated the rate-limit headers and never consumed the response body. Every SDK caller silently lost the entire report; there was no `Payload` field to read it from.

This points both 200 schemas at `domain.DownloadItem` in `transformation.jq`, matching the existing file-download handling for `report-files/v1`, `rules-files/v1`, and `rules-latest-files/v1`. The regenerated `...OK` structs now expose `Payload io.Writer` and the methods take an `io.Writer` sink, so callers can capture the downloaded report:

```go
var buf bytes.Buffer
_, err := client.Intel.GetMitreReport(
    intel.NewGetMitreReportParams().WithActorID("pristine-spider").WithFormat("json"),
    &buf,
)
// buf holds the raw JSON array (or CSV) of the MITRE ATT&CK mapping
```

Verified live against the API: the regenerated method streams the full report into the writer, where the previous code returned an empty struct.