### PR TITLE
fix(ml_exclusions): decode ExclusionV1 groups as string array (#680)

### DIFF
--- a/falcon/models/exclusions_exclusion_v1.go
+++ b/falcon/models/exclusions_exclusion_v1.go
@@ -7,7 +7,6 @@ package models
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -38,11 +37,14 @@ type ExclusionsExclusionV1 struct {
 
 	// groups
 	// Required: true
-	Groups []*HostGroupsHostGroupV1 `json:"groups"`
+	Groups []string `json:"groups"`
 
 	// id
 	// Required: true
 	ID *string `json:"id"`
+
+	// is descendant process
+	IsDescendantProcess bool `json:"is_descendant_process,omitempty"`
 
 	// last modified
 	// Required: true
@@ -153,24 +155,6 @@ func (m *ExclusionsExclusionV1) validateGroups(formats strfmt.Registry) error {
 		return err
 	}
 
-	for i := 0; i < len(m.Groups); i++ {
-		if swag.IsZero(m.Groups[i]) { // not required
-			continue
-		}
-
-		if m.Groups[i] != nil {
-			if err := m.Groups[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("groups" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce.ValidateName("groups" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
-
-	}
-
 	return nil
 }
 
@@ -232,42 +216,8 @@ func (m *ExclusionsExclusionV1) validateValueHash(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validate this exclusions exclusion v1 based on the context it is used
+// ContextValidate validates this exclusions exclusion v1 based on context it is used
 func (m *ExclusionsExclusionV1) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.contextValidateGroups(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *ExclusionsExclusionV1) contextValidateGroups(ctx context.Context, formats strfmt.Registry) error {
-
-	for i := 0; i < len(m.Groups); i++ {
-
-		if m.Groups[i] != nil {
-
-			if swag.IsZero(m.Groups[i]) { // not required
-				return nil
-			}
-
-			if err := m.Groups[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("groups" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce.ValidateName("groups" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
-
-	}
-
 	return nil
 }
 

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -841,3 +841,14 @@
 | .definitions."domain.ExclusionCreateReqV2".properties.is_descendant_process = {"type": "boolean"}
 | .definitions."domain.ExclusionUpdateReqV2".properties.applied_globally = {"type": "boolean"}
 | .definitions."domain.ExclusionUpdateReqV2".properties.is_descendant_process = {"type": "boolean"}
+
+# The ML (machine-learning) exclusions v2 response record (exclusions.ExclusionV1, the element
+# type of exclusions.RespV1.resources) declares "groups" as an array of host_groups.HostGroupV1
+# objects, but the live API returns an array of host-group ID strings. Decoding any real exclusion
+# that has host groups fails with "cannot unmarshal string into ... HostGroupsHostGroupV1". The
+# request models domain.ExclusionCreateReqV2/UpdateReqV2 already type groups as []string, so the
+# response record is the outlier. Override it to an array of strings. The spec also omits
+# is_descendant_process from this response record even though the live API returns it as a boolean,
+# so go-swagger silently drops it; add it as an optional boolean (verified present on live get).
+| .definitions."exclusions.ExclusionV1".properties.groups = {"type": "array", "items": {"type": "string"}}
+| .definitions."exclusions.ExclusionV1".properties.is_descendant_process = {"type": "boolean"}


### PR DESCRIPTION
The `groups` field on `exclusions.ExclusionV1` was generated as an array of `HostGroupsHostGroupV1` objects, but the ML exclusions v2 API returns an array of host-group ID strings. Any real exclusion with host groups failed to decode with `cannot unmarshal string into ... HostGroupsHostGroupV1`. The request models already use `[]string`, so the response record was the odd one out. This switches it to `[]string` via a `transformation.jq` override and regenerates.

I also added `is_descendant_process` to the same record. The live API returns it as a boolean here, but the spec never declared it, so go-swagger was quietly dropping it. #679 added that field to the request models but missed the response side.

Checked against a live tenant: `ExclusionsGetV2` now decodes 30 real exclusions, 21 of them with host groups, and no unmarshal error. Fixes #680.