### PR TITLE
fix(saas_security): decode array-of-object fields as typed objects

### DIFF
--- a/falcon/models/app_app_inventory.go
+++ b/falcon/models/app_app_inventory.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -74,7 +75,7 @@ type AppAppInventory struct {
 
 	// scopes
 	// Required: true
-	Scopes []*string `json:"scopes"`
+	Scopes []*AppAppInventoryScopesItems0 `json:"scopes"`
 
 	// Status
 	// Required: true
@@ -303,6 +304,24 @@ func (m *AppAppInventory) validateScopes(formats strfmt.Registry) error {
 		return err
 	}
 
+	for i := 0; i < len(m.Scopes); i++ {
+		if swag.IsZero(m.Scopes[i]) { // not required
+			continue
+		}
+
+		if m.Scopes[i] != nil {
+			if err := m.Scopes[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("scopes" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("scopes" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 
@@ -345,8 +364,42 @@ func (m *AppAppInventory) validateStatusReason(formats strfmt.Registry) error {
 	return nil
 }
 
-// ContextValidate validates this app app inventory based on context it is used
+// ContextValidate validate this app app inventory based on the context it is used
 func (m *AppAppInventory) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScopes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *AppAppInventory) contextValidateScopes(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Scopes); i++ {
+
+		if m.Scopes[i] != nil {
+
+			if swag.IsZero(m.Scopes[i]) { // not required
+				return nil
+			}
+
+			if err := m.Scopes[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("scopes" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("scopes" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 
@@ -361,6 +414,52 @@ func (m *AppAppInventory) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *AppAppInventory) UnmarshalBinary(b []byte) error {
 	var res AppAppInventory
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// AppAppInventoryScopesItems0 app app inventory scopes items0
+//
+// swagger:model AppAppInventoryScopesItems0
+type AppAppInventoryScopesItems0 struct {
+
+	// access level
+	AccessLevel *string `json:"access_level,omitempty"`
+
+	// is read
+	IsRead *bool `json:"is_read,omitempty"`
+
+	// is write
+	IsWrite *bool `json:"is_write,omitempty"`
+
+	// name
+	Name *string `json:"name,omitempty"`
+}
+
+// Validate validates this app app inventory scopes items0
+func (m *AppAppInventoryScopesItems0) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this app app inventory scopes items0 based on context it is used
+func (m *AppAppInventoryScopesItems0) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *AppAppInventoryScopesItems0) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *AppAppInventoryScopesItems0) UnmarshalBinary(b []byte) error {
+	var res AppAppInventoryScopesItems0
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/falcon/models/app_users_app_inventory_users.go
+++ b/falcon/models/app_users_app_inventory_users.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -30,7 +31,7 @@ type AppUsersAppInventoryUsers struct {
 
 	// users
 	// Required: true
-	Users []*string `json:"users"`
+	Users []*AppUsersAppInventoryUsersUsersItems0 `json:"users"`
 }
 
 // Validate validates this app users app inventory users
@@ -83,11 +84,63 @@ func (m *AppUsersAppInventoryUsers) validateUsers(formats strfmt.Registry) error
 		return err
 	}
 
+	for i := 0; i < len(m.Users); i++ {
+		if swag.IsZero(m.Users[i]) { // not required
+			continue
+		}
+
+		if m.Users[i] != nil {
+			if err := m.Users[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("users" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("users" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 
-// ContextValidate validates this app users app inventory users based on context it is used
+// ContextValidate validate this app users app inventory users based on the context it is used
 func (m *AppUsersAppInventoryUsers) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateUsers(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *AppUsersAppInventoryUsers) contextValidateUsers(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Users); i++ {
+
+		if m.Users[i] != nil {
+
+			if swag.IsZero(m.Users[i]) { // not required
+				return nil
+			}
+
+			if err := m.Users[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("users" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("users" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 
@@ -102,6 +155,46 @@ func (m *AppUsersAppInventoryUsers) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *AppUsersAppInventoryUsers) UnmarshalBinary(b []byte) error {
 	var res AppUsersAppInventoryUsers
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// AppUsersAppInventoryUsersUsersItems0 app users app inventory users users items0
+//
+// swagger:model AppUsersAppInventoryUsersUsersItems0
+type AppUsersAppInventoryUsersUsersItems0 struct {
+
+	// permission grant id
+	PermissionGrantID *string `json:"permission_grant_id,omitempty"`
+
+	// username
+	Username *string `json:"username,omitempty"`
+}
+
+// Validate validates this app users app inventory users users items0
+func (m *AppUsersAppInventoryUsersUsersItems0) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this app users app inventory users users items0 based on context it is used
+func (m *AppUsersAppInventoryUsersUsersItems0) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *AppUsersAppInventoryUsersUsersItems0) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *AppUsersAppInventoryUsersUsersItems0) UnmarshalBinary(b []byte) error {
+	var res AppUsersAppInventoryUsersUsersItems0
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/falcon/models/device_get_device_inventory.go
+++ b/falcon/models/device_get_device_inventory.go
@@ -7,6 +7,8 @@ package models
 
 import (
 	"context"
+	"encoding/json"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -81,11 +83,11 @@ type DeviceGetDeviceInventory struct {
 
 	// reported apps
 	// Required: true
-	ReportedApps []*string `json:"reported_apps"`
+	ReportedApps []*DeviceGetDeviceInventoryReportedAppsItems0 `json:"reported_apps"`
 
 	// reporters
 	// Required: true
-	Reporters []*string `json:"reporters"`
+	Reporters []*DeviceGetDeviceInventoryReportersItems0 `json:"reporters"`
 
 	// User email
 	// Required: true
@@ -330,6 +332,24 @@ func (m *DeviceGetDeviceInventory) validateReportedApps(formats strfmt.Registry)
 		return err
 	}
 
+	for i := 0; i < len(m.ReportedApps); i++ {
+		if swag.IsZero(m.ReportedApps[i]) { // not required
+			continue
+		}
+
+		if m.ReportedApps[i] != nil {
+			if err := m.ReportedApps[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("reported_apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("reported_apps" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 
@@ -337,6 +357,24 @@ func (m *DeviceGetDeviceInventory) validateReporters(formats strfmt.Registry) er
 
 	if err := validate.Required("reporters", "body", m.Reporters); err != nil {
 		return err
+	}
+
+	for i := 0; i < len(m.Reporters); i++ {
+		if swag.IsZero(m.Reporters[i]) { // not required
+			continue
+		}
+
+		if m.Reporters[i] != nil {
+			if err := m.Reporters[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("reporters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("reporters" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -364,8 +402,71 @@ func (m *DeviceGetDeviceInventory) validateUserExists(formats strfmt.Registry) e
 	return nil
 }
 
-// ContextValidate validates this device get device inventory based on context it is used
+// ContextValidate validate this device get device inventory based on the context it is used
 func (m *DeviceGetDeviceInventory) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateReportedApps(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateReporters(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DeviceGetDeviceInventory) contextValidateReportedApps(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ReportedApps); i++ {
+
+		if m.ReportedApps[i] != nil {
+
+			if swag.IsZero(m.ReportedApps[i]) { // not required
+				return nil
+			}
+
+			if err := m.ReportedApps[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("reported_apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("reported_apps" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *DeviceGetDeviceInventory) contextValidateReporters(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Reporters); i++ {
+
+		if m.Reporters[i] != nil {
+
+			if swag.IsZero(m.Reporters[i]) { // not required
+				return nil
+			}
+
+			if err := m.Reporters[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("reporters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("reporters" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 
@@ -380,6 +481,162 @@ func (m *DeviceGetDeviceInventory) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *DeviceGetDeviceInventory) UnmarshalBinary(b []byte) error {
 	var res DeviceGetDeviceInventory
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// DeviceGetDeviceInventoryReportedAppsItems0 device get device inventory reported apps items0
+//
+// swagger:model DeviceGetDeviceInventoryReportedAppsItems0
+type DeviceGetDeviceInventoryReportedAppsItems0 struct {
+
+	// app name
+	AppName *string `json:"app_name,omitempty"`
+
+	// device get device inventory reported apps items0 additional properties
+	DeviceGetDeviceInventoryReportedAppsItems0AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON unmarshals this object with additional properties from JSON
+func (m *DeviceGetDeviceInventoryReportedAppsItems0) UnmarshalJSON(data []byte) error {
+	// stage 1, bind the properties
+	var stage1 struct {
+
+		// app name
+		AppName *string `json:"app_name,omitempty"`
+	}
+	if err := json.Unmarshal(data, &stage1); err != nil {
+		return err
+	}
+	var rcv DeviceGetDeviceInventoryReportedAppsItems0
+
+	rcv.AppName = stage1.AppName
+	*m = rcv
+
+	// stage 2, remove properties and add to map
+	stage2 := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &stage2); err != nil {
+		return err
+	}
+
+	delete(stage2, "app_name")
+	// stage 3, add additional properties values
+	if len(stage2) > 0 {
+		result := make(map[string]interface{})
+		for k, v := range stage2 {
+			var toadd interface{}
+			if err := json.Unmarshal(v, &toadd); err != nil {
+				return err
+			}
+			result[k] = toadd
+		}
+		m.DeviceGetDeviceInventoryReportedAppsItems0AdditionalProperties = result
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals this object with additional properties into a JSON object
+func (m DeviceGetDeviceInventoryReportedAppsItems0) MarshalJSON() ([]byte, error) {
+	var stage1 struct {
+
+		// app name
+		AppName *string `json:"app_name,omitempty"`
+	}
+
+	stage1.AppName = m.AppName
+
+	// make JSON object for known properties
+	props, err := json.Marshal(stage1)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.DeviceGetDeviceInventoryReportedAppsItems0AdditionalProperties) == 0 { // no additional properties
+		return props, nil
+	}
+
+	// make JSON object for the additional properties
+	additional, err := json.Marshal(m.DeviceGetDeviceInventoryReportedAppsItems0AdditionalProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(props) < 3 { // "{}": only additional properties
+		return additional, nil
+	}
+
+	// concatenate the 2 objects
+	return swag.ConcatJSON(props, additional), nil
+}
+
+// Validate validates this device get device inventory reported apps items0
+func (m *DeviceGetDeviceInventoryReportedAppsItems0) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this device get device inventory reported apps items0 based on context it is used
+func (m *DeviceGetDeviceInventoryReportedAppsItems0) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *DeviceGetDeviceInventoryReportedAppsItems0) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *DeviceGetDeviceInventoryReportedAppsItems0) UnmarshalBinary(b []byte) error {
+	var res DeviceGetDeviceInventoryReportedAppsItems0
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// DeviceGetDeviceInventoryReportersItems0 device get device inventory reporters items0
+//
+// swagger:model DeviceGetDeviceInventoryReportersItems0
+type DeviceGetDeviceInventoryReportersItems0 struct {
+
+	// alias
+	Alias *string `json:"alias,omitempty"`
+
+	// integration id
+	IntegrationID *string `json:"integration_id,omitempty"`
+
+	// title
+	Title *string `json:"title,omitempty"`
+}
+
+// Validate validates this device get device inventory reporters items0
+func (m *DeviceGetDeviceInventoryReportersItems0) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this device get device inventory reporters items0 based on context it is used
+func (m *DeviceGetDeviceInventoryReportersItems0) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *DeviceGetDeviceInventoryReportersItems0) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *DeviceGetDeviceInventoryReportersItems0) UnmarshalBinary(b []byte) error {
+	var res DeviceGetDeviceInventoryReportersItems0
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -854,3 +854,63 @@
 # so go-swagger silently drops it; add it as an optional boolean (verified present on live get).
 | .definitions."exclusions.ExclusionV1".properties.groups = {"type": "array", "items": {"type": "string"}}
 | .definitions."exclusions.ExclusionV1".properties.is_descendant_process = {"type": "boolean"}
+
+# --- SaaS Security (Falcon Shield) array-of-object fixes ---
+# The spec types several SaaS Security record fields as arrays of strings, but
+# the live API returns arrays of objects. go-swagger generates []*string for
+# them, so decoding any real response panics with
+# "cannot unmarshal object into Go struct field ... of type string".
+# Retype each to an array of objects matching the live response shape (verified
+# live 2026-07-21). Objects are defined inline so go-swagger emits nested typed
+# structs; additionalProperties:true tolerates fields not modeled here.
+#
+# Device_GetDeviceInventory.reporters: which integrations reported the device.
+| .definitions."Device_GetDeviceInventory".properties.reporters = {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "integration_id": {"type": "string", "x-nullable": true},
+        "alias": {"type": "string", "x-nullable": true},
+        "title": {"type": "string", "x-nullable": true}
+      }
+    }
+  }
+# Device_GetDeviceInventory.reported_apps: apps observed on the device. Shape is
+# heterogeneous (Falcon adds score/vulnerabilities; other integrations add
+# fields), so only app_name is modeled and additionalProperties is allowed.
+| .definitions."Device_GetDeviceInventory".properties.reported_apps = {
+    "type": "array",
+    "x-nullable": true,
+    "items": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "app_name": {"type": "string", "x-nullable": true}
+      }
+    }
+  }
+# App_AppInventory.scopes: OAuth/permission scopes granted to the app.
+| .definitions."App_AppInventory".properties.scopes = {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string", "x-nullable": true},
+        "access_level": {"type": "string", "x-nullable": true},
+        "is_read": {"type": "boolean", "x-nullable": true},
+        "is_write": {"type": "boolean", "x-nullable": true}
+      }
+    }
+  }
+# AppUsers_AppInventoryUsers.users: users associated with the app.
+| .definitions."AppUsers_AppInventoryUsers".properties.users = {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "username": {"type": "string", "x-nullable": true},
+        "permission_grant_id": {"type": "string", "x-nullable": true}
+      }
+    }
+  }


### PR DESCRIPTION
Four SaaS Security (Falcon Shield) record fields are declared in the spec as arrays of strings, but the live API returns arrays of objects. go-swagger generates `[]*string` for them, so decoding any real response panics with `cannot unmarshal object into Go struct field ... of type string`:

- `Device_GetDeviceInventory.reporters` — objects with `integration_id`, `alias`, `title`
- `Device_GetDeviceInventory.reported_apps` — objects with `app_name` plus heterogeneous extras (Falcon adds `score`/`vulnerabilities`; other integrations add `fields`)
- `App_AppInventory.scopes` — objects with `name`, `access_level`, `is_read`, `is_write`
- `AppUsers_AppInventoryUsers.users` — objects with `username`, `permission_grant_id`

Each field is retyped in `specs/transformation.jq` to an array of objects matching the live response shape (verified against a live tenant on 2026-07-21), and the affected models regenerated. `reported_apps` uses `additionalProperties: true` because its shape varies by reporting integration.

Verified: `GetDeviceInventoryV3`, `GetAppInventory`, and `GetAppInventoryUsers` all decode real tenant responses without error after the change (they panicked before).