### PR TITLE
fix(exclusions): make IOA/CB response fields nullable to preserve fidelity

### DIFF
--- a/falcon/models/api_cert_based_exclusion_v1.go
+++ b/falcon/models/api_cert_based_exclusion_v1.go
@@ -20,7 +20,7 @@ import (
 type APICertBasedExclusionV1 struct {
 
 	// applied globally
-	AppliedGlobally bool `json:"applied_globally,omitempty"`
+	AppliedGlobally *bool `json:"applied_globally,omitempty"`
 
 	// certificate
 	Certificate *APICertificateV1 `json:"certificate,omitempty"`
@@ -33,7 +33,7 @@ type APICertBasedExclusionV1 struct {
 	Cid *string `json:"cid"`
 
 	// comment
-	Comment string `json:"comment,omitempty"`
+	Comment *string `json:"comment,omitempty"`
 
 	// created by
 	CreatedBy string `json:"created_by,omitempty"`

--- a/falcon/models/domain_ss_ioa_exclusions_v2.go
+++ b/falcon/models/domain_ss_ioa_exclusions_v2.go
@@ -20,13 +20,13 @@ import (
 type DomainSsIoaExclusionsV2 struct {
 
 	// applied globally
-	AppliedGlobally bool `json:"applied_globally,omitempty"`
+	AppliedGlobally *bool `json:"applied_globally,omitempty"`
 
 	// cl regex
 	ClRegex string `json:"cl_regex,omitempty"`
 
 	// comment
-	Comment string `json:"comment,omitempty"`
+	Comment *string `json:"comment,omitempty"`
 
 	// created by
 	CreatedBy string `json:"created_by,omitempty"`
@@ -36,7 +36,7 @@ type DomainSsIoaExclusionsV2 struct {
 	CreatedOn strfmt.DateTime `json:"created_on,omitempty"`
 
 	// description
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// detection json
 	DetectionJSON string `json:"detection_json,omitempty"`

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -928,3 +928,17 @@
       }
     }
   }
+
+# IOA (domain.SsIoaExclusionsV2) and certificate-based (api.CertBasedExclusionV1) exclusion RESPONSE
+# records carry applied_globally/comment/description on some records and omit them on others (verified
+# live: IOA applied_globally was false on some records and absent on others). With go-swagger's default
+# omitempty on these value-typed fields, a typed decode-then-reencode cannot reproduce that shape — it
+# drops false and "" — so a typed round-trip loses data the raw API sent. Make them nullable (*bool/*string)
+# so present values (including false/"") serialize and absent values stay nil, faithfully reproducing the
+# live present/absent-per-record pattern. Narrow to only the fields proven dropped; the other response
+# fields are always sent and must stay non-optional.
+| .definitions."domain.SsIoaExclusionsV2".properties.applied_globally += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.comment          += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.description       += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.applied_globally  += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.comment           += {"x-nullable": true}


### PR DESCRIPTION
The IOA (`domain.SsIoaExclusionsV2`) and certificate-based (`api.CertBasedExclusionV1`) exclusion response records type `applied_globally`, `comment`, and `description` as plain value types with the default `omitempty`. The live API sends these fields on some records and omits them on others — for example, a live IOA get returns `applied_globally: false` on some records and omits the key entirely on others.

Because go-swagger emits `omitempty` on the value types, a typed decode-then-reencode of these responses cannot reproduce that shape: it drops `false` and `""`, so a round-trip silently loses data the API actually sent. This blocks any consumer that needs the response to faithfully mirror the API body (e.g. surfacing exclusion records verbatim).

This makes the proven-dropped fields nullable (`*bool`/`*string`) so a present value — including `false`/`""` — serializes while an absent value stays `nil`, faithfully reproducing the live present/absent-per-record pattern. Only the fields observed to drop are changed; the always-present response fields stay non-optional so required fields are not mismodeled as optional.

Verified against a live tenant: IOA and certificate-based gets now decode `applied_globally`/`comment`/`description` with `false` preserved where present and `nil` where the key is absent.