### PR TITLE
fix(exclusions): make all optional response fields nullable to preserve fidelity

### DIFF
--- a/falcon/models/api_cert_based_exclusion_v1.go
+++ b/falcon/models/api_cert_based_exclusion_v1.go
@@ -36,14 +36,14 @@ type APICertBasedExclusionV1 struct {
 	Comment *string `json:"comment,omitempty"`
 
 	// created by
-	CreatedBy string `json:"created_by,omitempty"`
+	CreatedBy *string `json:"created_by,omitempty"`
 
 	// created on
 	// Format: date-time
-	CreatedOn strfmt.DateTime `json:"created_on,omitempty"`
+	CreatedOn *strfmt.DateTime `json:"created_on,omitempty"`
 
 	// description
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// host groups
 	HostGroups []string `json:"host_groups"`
@@ -53,17 +53,17 @@ type APICertBasedExclusionV1 struct {
 	ID *string `json:"id"`
 
 	// modified by
-	ModifiedBy string `json:"modified_by,omitempty"`
+	ModifiedBy *string `json:"modified_by,omitempty"`
 
 	// modified on
 	// Format: date-time
-	ModifiedOn strfmt.DateTime `json:"modified_on,omitempty"`
+	ModifiedOn *strfmt.DateTime `json:"modified_on,omitempty"`
 
 	// name
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// status
-	Status string `json:"status,omitempty"`
+	Status *string `json:"status,omitempty"`
 }
 
 // Validate validates this api cert based exclusion v1

--- a/falcon/models/domain_ss_ioa_exclusions_v2.go
+++ b/falcon/models/domain_ss_ioa_exclusions_v2.go
@@ -23,61 +23,61 @@ type DomainSsIoaExclusionsV2 struct {
 	AppliedGlobally *bool `json:"applied_globally,omitempty"`
 
 	// cl regex
-	ClRegex string `json:"cl_regex,omitempty"`
+	ClRegex *string `json:"cl_regex,omitempty"`
 
 	// comment
 	Comment *string `json:"comment,omitempty"`
 
 	// created by
-	CreatedBy string `json:"created_by,omitempty"`
+	CreatedBy *string `json:"created_by,omitempty"`
 
 	// created on
 	// Format: date-time
-	CreatedOn strfmt.DateTime `json:"created_on,omitempty"`
+	CreatedOn *strfmt.DateTime `json:"created_on,omitempty"`
 
 	// description
 	Description *string `json:"description,omitempty"`
 
 	// detection json
-	DetectionJSON string `json:"detection_json,omitempty"`
+	DetectionJSON *string `json:"detection_json,omitempty"`
 
 	// grandparent cl regex
-	GrandparentClRegex string `json:"grandparent_cl_regex,omitempty"`
+	GrandparentClRegex *string `json:"grandparent_cl_regex,omitempty"`
 
 	// grandparent ifn regex
-	GrandparentIfnRegex string `json:"grandparent_ifn_regex,omitempty"`
+	GrandparentIfnRegex *string `json:"grandparent_ifn_regex,omitempty"`
 
 	// host groups
-	HostGroups []string `json:"host_groups"`
+	HostGroups []string `json:"host_groups,omitempty"`
 
 	// id
 	// Required: true
 	ID *string `json:"id"`
 
 	// ifn regex
-	IfnRegex string `json:"ifn_regex,omitempty"`
+	IfnRegex *string `json:"ifn_regex,omitempty"`
 
 	// last modified
 	// Format: date-time
-	LastModified strfmt.DateTime `json:"last_modified,omitempty"`
+	LastModified *strfmt.DateTime `json:"last_modified,omitempty"`
 
 	// modified by
-	ModifiedBy string `json:"modified_by,omitempty"`
+	ModifiedBy *string `json:"modified_by,omitempty"`
 
 	// name
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// parent cl regex
-	ParentClRegex string `json:"parent_cl_regex,omitempty"`
+	ParentClRegex *string `json:"parent_cl_regex,omitempty"`
 
 	// parent ifn regex
-	ParentIfnRegex string `json:"parent_ifn_regex,omitempty"`
+	ParentIfnRegex *string `json:"parent_ifn_regex,omitempty"`
 
 	// pattern id
-	PatternID string `json:"pattern_id,omitempty"`
+	PatternID *string `json:"pattern_id,omitempty"`
 
 	// pattern name
-	PatternName string `json:"pattern_name,omitempty"`
+	PatternName *string `json:"pattern_name,omitempty"`
 }
 
 // Validate validates this domain ss ioa exclusions v2

--- a/falcon/models/exclusions_exclusion_v1.go
+++ b/falcon/models/exclusions_exclusion_v1.go
@@ -44,7 +44,7 @@ type ExclusionsExclusionV1 struct {
 	ID *string `json:"id"`
 
 	// is descendant process
-	IsDescendantProcess bool `json:"is_descendant_process,omitempty"`
+	IsDescendantProcess *bool `json:"is_descendant_process,omitempty"`
 
 	// last modified
 	// Required: true

--- a/falcon/models/sv_exclusions_s_v_exclusion_v1.go
+++ b/falcon/models/sv_exclusions_s_v_exclusion_v1.go
@@ -42,7 +42,7 @@ type SvExclusionsSVExclusionV1 struct {
 	ID *string `json:"id"`
 
 	// is descendant process
-	IsDescendantProcess bool `json:"is_descendant_process,omitempty"`
+	IsDescendantProcess *bool `json:"is_descendant_process,omitempty"`
 
 	// last modified
 	// Required: true

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -942,3 +942,44 @@
 | .definitions."domain.SsIoaExclusionsV2".properties.description       += {"x-nullable": true}
 | .definitions."api.CertBasedExclusionV1".properties.applied_globally  += {"x-nullable": true}
 | .definitions."api.CertBasedExclusionV1".properties.comment           += {"x-nullable": true}
+
+# Exhaustive fidelity fix for the four exclusion RESPONSE record models: every OPTIONAL
+# (non-required) value field is made nullable. go-swagger tags optional value fields with
+# omitempty, so a typed decode-then-reencode drops any field the live API sent present-as-zero
+# (false / "" / a zero timestamp) and can emit a zero value for one the API omitted. The live
+# API sends these optional fields on some records and omits them on others, so a faithful 1:1
+# round-trip (the tool returns raw-API-equivalent records) requires pointers: present values —
+# including false/"" — serialize, absent values stay nil. This generalizes the earlier
+# applied_globally/comment/description fix (#686) to the whole class so no optional field is
+# silently dropped. Required fields already generate as non-omitempty pointers and are left as-is;
+# arrays and object refs are already nil-able and are left as-is.
+| .definitions."exclusions.ExclusionV1".properties.is_descendant_process    += {"x-nullable": true}
+| .definitions."sv_exclusions.SVExclusionV1".properties.is_descendant_process += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.cl_regex               += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.created_by             += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.created_on             += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.detection_json         += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.grandparent_cl_regex   += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.grandparent_ifn_regex  += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.ifn_regex              += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.last_modified          += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.modified_by            += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.name                   += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.parent_cl_regex        += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.parent_ifn_regex       += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.pattern_id             += {"x-nullable": true}
+| .definitions."domain.SsIoaExclusionsV2".properties.pattern_name           += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.created_by             += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.created_on             += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.description            += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.modified_by            += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.modified_on            += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.name                   += {"x-nullable": true}
+| .definitions."api.CertBasedExclusionV1".properties.status                 += {"x-nullable": true}
+# IOA host_groups is the one optional ARRAY that needs omitempty rather than nullable: the live
+# API sends it populated on scoped exclusions and OMITS it entirely on globally-applied ones (never
+# as [] or null). Without omitempty go-swagger emits "host_groups":null for the omit case, adding a
+# key the raw body never had. x-omitempty makes a nil slice omit, reproducing absent-vs-populated
+# exactly. (ML/SV groups and excluded_from, and CB children_cids/host_groups, are always present in
+# the live body — populated or [] — so they already round-trip and are left unchanged.)
+| .definitions."domain.SsIoaExclusionsV2".properties.host_groups += {"x-omitempty": true}


### PR DESCRIPTION
Follow-up to #686. That PR made `applied_globally`/`comment`/`description` nullable on the IOA and certificate-based exclusion response records, but the same omitempty-drops-a-present-zero-value bug affects every other optional value field on the four exclusion response record models. A typed decode-then-reencode of these responses silently drops any optional scalar the live API sent present-as-zero (`false`, `""`, a zero timestamp) and emits `null` for an optional array the API omitted, so a consumer that returns raw-API-equivalent records cannot reproduce the live body.

This generalizes the fix to the whole class across `exclusions.ExclusionV1`, `sv_exclusions.SVExclusionV1`, `domain.SsIoaExclusionsV2`, and `api.CertBasedExclusionV1`:

- Every optional (non-required) scalar/timestamp field is made nullable (`*bool`/`*string`/`*strfmt.DateTime`) so a present-but-zero value serializes and an absent one stays nil. This covers ML/SV `is_descendant_process`; IOA `cl_regex`, `ifn_regex`, `parent_*`/`grandparent_*` regexes, `pattern_id`, `pattern_name`, `name`, `detection_json`, `created_by`, `created_on`, `modified_by`, `last_modified`; and CB `created_by`, `created_on`, `description`, `modified_by`, `modified_on`, `name`, `status`.
- IOA `host_groups` gets `x-omitempty` instead: the live API omits it entirely on globally-applied exclusions and never sends `[]`/`null` there, so a nil slice must omit rather than serialize as `null`.

Required fields already generate as non-omitempty pointers and are left as-is; the other optional arrays (ML/SV `groups`, ML `excluded_from`, CB `children_cids`/`host_groups`) are always present in the live body (populated or `[]`) and already round-trip, so they are unchanged.

Verified against a live tenant across all four types: the typed model's JSON round-trip now reproduces the raw API response body key-for-key on every record (ML 30/30, SV 18/18, IOA 35/35, CB 2/2), where before this fix optional present-zero fields were dropped.