### PR TITLE
fix(ml_exclusions): decode v2 exclusion creates as 201 Created

### DIFF
--- a/falcon/client/ml_exclusions/exclusions_create_v2_responses.go
+++ b/falcon/client/ml_exclusions/exclusions_create_v2_responses.go
@@ -25,8 +25,8 @@ type ExclusionsCreateV2Reader struct {
 // ReadResponse reads a server response into the received o.
 func (o *ExclusionsCreateV2Reader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
-	case 200:
-		result := NewExclusionsCreateV2OK()
+	case 201:
+		result := NewExclusionsCreateV2Created()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -54,17 +54,17 @@ func (o *ExclusionsCreateV2Reader) ReadResponse(response runtime.ClientResponse,
 	}
 }
 
-// NewExclusionsCreateV2OK creates a ExclusionsCreateV2OK with default headers values
-func NewExclusionsCreateV2OK() *ExclusionsCreateV2OK {
-	return &ExclusionsCreateV2OK{}
+// NewExclusionsCreateV2Created creates a ExclusionsCreateV2Created with default headers values
+func NewExclusionsCreateV2Created() *ExclusionsCreateV2Created {
+	return &ExclusionsCreateV2Created{}
 }
 
 /*
-ExclusionsCreateV2OK describes a response with status code 200, with default header values.
+ExclusionsCreateV2Created describes a response with status code 201, with default header values.
 
 OK
 */
-type ExclusionsCreateV2OK struct {
+type ExclusionsCreateV2Created struct {
 
 	/* Trace-ID: submit to support if resolving an issue
 	 */
@@ -81,49 +81,49 @@ type ExclusionsCreateV2OK struct {
 	Payload *models.ExclusionsRespV1
 }
 
-// IsSuccess returns true when this exclusions create v2 o k response has a 2xx status code
-func (o *ExclusionsCreateV2OK) IsSuccess() bool {
+// IsSuccess returns true when this exclusions create v2 created response has a 2xx status code
+func (o *ExclusionsCreateV2Created) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this exclusions create v2 o k response has a 3xx status code
-func (o *ExclusionsCreateV2OK) IsRedirect() bool {
+// IsRedirect returns true when this exclusions create v2 created response has a 3xx status code
+func (o *ExclusionsCreateV2Created) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this exclusions create v2 o k response has a 4xx status code
-func (o *ExclusionsCreateV2OK) IsClientError() bool {
+// IsClientError returns true when this exclusions create v2 created response has a 4xx status code
+func (o *ExclusionsCreateV2Created) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this exclusions create v2 o k response has a 5xx status code
-func (o *ExclusionsCreateV2OK) IsServerError() bool {
+// IsServerError returns true when this exclusions create v2 created response has a 5xx status code
+func (o *ExclusionsCreateV2Created) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this exclusions create v2 o k response a status code equal to that given
-func (o *ExclusionsCreateV2OK) IsCode(code int) bool {
-	return code == 200
+// IsCode returns true when this exclusions create v2 created response a status code equal to that given
+func (o *ExclusionsCreateV2Created) IsCode(code int) bool {
+	return code == 201
 }
 
-// Code gets the status code for the exclusions create v2 o k response
-func (o *ExclusionsCreateV2OK) Code() int {
-	return 200
+// Code gets the status code for the exclusions create v2 created response
+func (o *ExclusionsCreateV2Created) Code() int {
+	return 201
 }
 
-func (o *ExclusionsCreateV2OK) Error() string {
-	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2OK  %+v", 200, o.Payload)
+func (o *ExclusionsCreateV2Created) Error() string {
+	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2Created  %+v", 201, o.Payload)
 }
 
-func (o *ExclusionsCreateV2OK) String() string {
-	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2OK  %+v", 200, o.Payload)
+func (o *ExclusionsCreateV2Created) String() string {
+	return fmt.Sprintf("[POST /exclusions/entities/exclusions/v2][%d] exclusionsCreateV2Created  %+v", 201, o.Payload)
 }
 
-func (o *ExclusionsCreateV2OK) GetPayload() *models.ExclusionsRespV1 {
+func (o *ExclusionsCreateV2Created) GetPayload() *models.ExclusionsRespV1 {
 	return o.Payload
 }
 
-func (o *ExclusionsCreateV2OK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *ExclusionsCreateV2Created) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// hydrates response header X-CS-TRACEID
 	hdrXCSTRACEID := response.GetHeader("X-CS-TRACEID")

--- a/falcon/client/ml_exclusions/ml_exclusions_client.go
+++ b/falcon/client/ml_exclusions/ml_exclusions_client.go
@@ -36,7 +36,7 @@ type ClientService interface {
 
 	ExclusionsAggregatesV2(params *ExclusionsAggregatesV2Params, opts ...ClientOption) (*ExclusionsAggregatesV2OK, error)
 
-	ExclusionsCreateV2(params *ExclusionsCreateV2Params, opts ...ClientOption) (*ExclusionsCreateV2OK, error)
+	ExclusionsCreateV2(params *ExclusionsCreateV2Params, opts ...ClientOption) (*ExclusionsCreateV2Created, error)
 
 	ExclusionsDeleteV2(params *ExclusionsDeleteV2Params, opts ...ClientOption) (*ExclusionsDeleteV2OK, error)
 
@@ -180,7 +180,7 @@ func (a *Client) ExclusionsAggregatesV2(params *ExclusionsAggregatesV2Params, op
 /*
 ExclusionsCreateV2 creates the exclusions with ancestor fields
 */
-func (a *Client) ExclusionsCreateV2(params *ExclusionsCreateV2Params, opts ...ClientOption) (*ExclusionsCreateV2OK, error) {
+func (a *Client) ExclusionsCreateV2(params *ExclusionsCreateV2Params, opts ...ClientOption) (*ExclusionsCreateV2Created, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewExclusionsCreateV2Params()
@@ -205,7 +205,7 @@ func (a *Client) ExclusionsCreateV2(params *ExclusionsCreateV2Params, opts ...Cl
 	if err != nil {
 		return nil, err
 	}
-	success, ok := result.(*ExclusionsCreateV2OK)
+	success, ok := result.(*ExclusionsCreateV2Created)
 	if ok {
 		return success, nil
 	}

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -866,6 +866,13 @@
 | .paths."/exclusions/entities/exclusions/v2"."patch"."responses"."200"."schema" = {"$ref": "#/definitions/exclusions.RespV1"}
 | .paths."/exclusions/entities/exclusions/v2"."delete"."responses"."200"."schema"= {"$ref": "#/definitions/msaspec.QueryResponse"}
 
+# 201 is a valid response for POST /exclusions/entities/exclusions/v2, 200 is not. The live API
+# answers a create with 201 Created, so the generated reader treats every success as an unknown
+# status and returns an error. Must run after the 200 schema fix above so the copied response
+# carries the exclusions.RespV1 schema and not an empty body.
+| .paths."/exclusions/entities/exclusions/v2".post.responses."201" = .paths."/exclusions/entities/exclusions/v2".post.responses."200"
+| del(.paths."/exclusions/entities/exclusions/v2".post.responses."200")
+
 # The ML (machine-learning) exclusions v2 create/update request bodies accept applied_globally
 # and is_descendant_process, but the spec omits both from the request definitions. Add them as
 # optional booleans (verified accepted on live create/update) so callers can set them, matching


### PR DESCRIPTION
The live API answers POST /exclusions/entities/exclusions/v2 with 201 Created, but the spec declared only a 200 response, so the generated reader treated every successful create as an unknown status and returned an error instead of the created exclusion. Move the response to 201 so creates decode into an ExclusionsRespV1 payload, matching the fix already applied to the ml-exclusions and sv-exclusions v1 create endpoints.