### PR TITLE
fix(insights): preserve zero-valued insights.External fields via x-nullable

### DIFF
--- a/falcon/models/apimodels_rule.go
+++ b/falcon/models/apimodels_rule.go
@@ -24,6 +24,9 @@ type ApimodelsRule struct {
 	// Required: true
 	AlertInfo *string `json:"alert_info"`
 
+	// annotation status
+	AnnotationStatus string `json:"annotation_status,omitempty"`
+
 	// attack types
 	AttackTypes []string `json:"attack_types"`
 
@@ -75,6 +78,9 @@ type ApimodelsRule struct {
 	// domain
 	// Required: true
 	Domain *string `json:"domain"`
+
+	// insight id
+	InsightID string `json:"insight_id,omitempty"`
 
 	// logic
 	Logic string `json:"logic,omitempty"`

--- a/falcon/models/insights_external.go
+++ b/falcon/models/insights_external.go
@@ -20,27 +20,27 @@ import (
 type InsightsExternal struct {
 
 	// boolean value
-	BooleanValue bool `json:"booleanValue,omitempty"`
+	BooleanValue *bool `json:"booleanValue,omitempty"`
 
 	// date value
 	// Format: date-time
-	DateValue strfmt.DateTime `json:"dateValue,omitempty"`
+	DateValue *strfmt.DateTime `json:"dateValue,omitempty"`
 
 	// id
 	// Required: true
 	ID *string `json:"id"`
 
 	// integer value
-	IntegerValue int32 `json:"integerValue,omitempty"`
+	IntegerValue *int32 `json:"integerValue,omitempty"`
 
 	// rule Id
 	RuleID string `json:"ruleId,omitempty"`
 
 	// string list value
-	StringListValue []string `json:"stringListValue"`
+	StringListValue []string `json:"stringListValue,omitempty"`
 
 	// string value
-	StringValue string `json:"stringValue,omitempty"`
+	StringValue *string `json:"stringValue,omitempty"`
 }
 
 // Validate validates this insights external

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -854,6 +854,19 @@
 # a real response (an array type fails to unmarshal the object the API returns).
 | .definitions."vulnerabilities.VulnerabilityEntitySARIFResponse".properties.resources = {"$ref": "#/definitions/models.VulnerabilitySARIF"}
 
+# insights.External models a single insight value as flat primitive siblings (booleanValue,
+# dateValue, integerValue, stringValue, stringListValue), only one of which is populated per
+# record. The default codegen loses data: a value-typed "booleanValue,omitempty" drops a real
+# false, omitempty is a no-op on the strfmt.DateTime struct so an unset dateValue marshals as
+# "0001-01-01T00:00:00.000Z", and an array without omitempty emits nil as null on every record.
+# Make the scalars nullable (pointers: nil when absent, zero preserved when set) and give the
+# array omitempty, so an absent value is omitted rather than corrupted.
+| .definitions."insights.External".properties.booleanValue    += {"x-nullable": true}
+| .definitions."insights.External".properties.dateValue       += {"x-nullable": true}
+| .definitions."insights.External".properties.integerValue    += {"x-nullable": true}
+| .definitions."insights.External".properties.stringValue      += {"x-nullable": true}
+| .definitions."insights.External".properties.stringListValue += {"x-omitempty": true}
+
 # The ML (machine-learning) exclusions v2 operations declare an empty {} 200 response
 # schema, so go-swagger falls back to msa.ReplyMetaOnly and silently drops every resource
 # the API returns. The record shape matches the existing v1 definitions, so point the 200


### PR DESCRIPTION
insights.External modeled its polymorphic value as flat primitive siblings, producing a lossy generated struct: a false booleanValue was dropped by omitempty, an unset dateValue marshaled a phantom "0001-01-01T..." (omitempty is a no-op on a struct), and a nil stringListValue was always emitted as null.

Patch transformation.jq to add x-nullable to booleanValue/dateValue/ integerValue/stringValue (scalars become pointers, so absent != zero) and x-omitempty to stringListValue, then regenerate.

Regeneration also surfaces insight_id (and annotation_status) on apimodels.Rule, which were present in the spec but stale in generated code.