### PR TITLE
fix(report_executions)!: decode download response body

### DIFF
--- a/falcon/client/report_executions/report_executions_client.go
+++ b/falcon/client/report_executions/report_executions_client.go
@@ -7,6 +7,7 @@ package report_executions
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
@@ -30,7 +31,7 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	ReportExecutionsDownloadGet(params *ReportExecutionsDownloadGetParams, opts ...ClientOption) (*ReportExecutionsDownloadGetOK, error)
+	ReportExecutionsDownloadGet(params *ReportExecutionsDownloadGetParams, writer io.Writer, opts ...ClientOption) (*ReportExecutionsDownloadGetOK, error)
 
 	ReportExecutionsGet(params *ReportExecutionsGetParams, opts ...ClientOption) (*ReportExecutionsGetOK, error)
 
@@ -44,7 +45,7 @@ type ClientService interface {
 /*
 ReportExecutionsDownloadGet gets report entity download
 */
-func (a *Client) ReportExecutionsDownloadGet(params *ReportExecutionsDownloadGetParams, opts ...ClientOption) (*ReportExecutionsDownloadGetOK, error) {
+func (a *Client) ReportExecutionsDownloadGet(params *ReportExecutionsDownloadGetParams, writer io.Writer, opts ...ClientOption) (*ReportExecutionsDownloadGetOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewReportExecutionsDownloadGetParams()
@@ -57,7 +58,7 @@ func (a *Client) ReportExecutionsDownloadGet(params *ReportExecutionsDownloadGet
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
 		Params:             params,
-		Reader:             &ReportExecutionsDownloadGetReader{formats: a.formats},
+		Reader:             &ReportExecutionsDownloadGetReader{formats: a.formats, writer: writer},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
 	}

--- a/falcon/client/report_executions/report_executions_download_get_responses.go
+++ b/falcon/client/report_executions/report_executions_download_get_responses.go
@@ -20,13 +20,14 @@ import (
 // ReportExecutionsDownloadGetReader is a Reader for the ReportExecutionsDownloadGet structure.
 type ReportExecutionsDownloadGetReader struct {
 	formats strfmt.Registry
+	writer  io.Writer
 }
 
 // ReadResponse reads a server response into the received o.
 func (o *ReportExecutionsDownloadGetReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 	case 200:
-		result := NewReportExecutionsDownloadGetOK()
+		result := NewReportExecutionsDownloadGetOK(o.writer)
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -61,8 +62,11 @@ func (o *ReportExecutionsDownloadGetReader) ReadResponse(response runtime.Client
 }
 
 // NewReportExecutionsDownloadGetOK creates a ReportExecutionsDownloadGetOK with default headers values
-func NewReportExecutionsDownloadGetOK() *ReportExecutionsDownloadGetOK {
-	return &ReportExecutionsDownloadGetOK{}
+func NewReportExecutionsDownloadGetOK(writer io.Writer) *ReportExecutionsDownloadGetOK {
+	return &ReportExecutionsDownloadGetOK{
+
+		Payload: writer,
+	}
 }
 
 /*
@@ -83,6 +87,8 @@ type ReportExecutionsDownloadGetOK struct {
 	/* The number of requests remaining for the sliding one minute window.
 	 */
 	XRateLimitRemaining int64
+
+	Payload io.Writer
 }
 
 // IsSuccess returns true when this report executions download get o k response has a 2xx status code
@@ -116,11 +122,15 @@ func (o *ReportExecutionsDownloadGetOK) Code() int {
 }
 
 func (o *ReportExecutionsDownloadGetOK) Error() string {
-	return fmt.Sprintf("[GET /reports/entities/report-executions-download/v1][%d] reportExecutionsDownloadGetOK ", 200)
+	return fmt.Sprintf("[GET /reports/entities/report-executions-download/v1][%d] reportExecutionsDownloadGetOK  %+v", 200, o.Payload)
 }
 
 func (o *ReportExecutionsDownloadGetOK) String() string {
-	return fmt.Sprintf("[GET /reports/entities/report-executions-download/v1][%d] reportExecutionsDownloadGetOK ", 200)
+	return fmt.Sprintf("[GET /reports/entities/report-executions-download/v1][%d] reportExecutionsDownloadGetOK  %+v", 200, o.Payload)
+}
+
+func (o *ReportExecutionsDownloadGetOK) GetPayload() io.Writer {
+	return o.Payload
 }
 
 func (o *ReportExecutionsDownloadGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -152,6 +162,11 @@ func (o *ReportExecutionsDownloadGetOK) readResponse(response runtime.ClientResp
 			return errors.InvalidType("X-RateLimit-Remaining", "header", "int64", hdrXRateLimitRemaining)
 		}
 		o.XRateLimitRemaining = valxRateLimitRemaining
+	}
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
 	}
 
 	return nil

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -10,6 +10,7 @@
   | .paths."/intel/entities/mitre-reports/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   | .paths."/intel/entities/malware-mitre-reports/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   | .paths."/real-time-response/entities/extracted-file-contents/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
+  | .paths."/reports/entities/report-executions-download/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   # Fix overflow on json number (more than 63 bits are needed hold this field)
   | .definitions."domain.APIEvaluationLogicItemV1".properties.id."x-go-type"={type: "Number", import: {package: "encoding/json"}, hints: {noValidation: true}}
   | .definitions."domain.APISimplifiedEvaluationLogicItemV1".properties.id."x-go-type"={type: "Number", import: {package: "encoding/json"}, hints: {noValidation: true}}


### PR DESCRIPTION
The 200 response for GET /reports/entities/report-executions-download/v1 declared only headers and no body schema, so go-swagger generated a header-only ReportExecutionsDownloadGetOK with no Payload field and a readResponse that never called consumer.Consume — silently discarding the downloaded file bytes.

Wire the 200 response to domain.DownloadItem in transformation.jq (the same binary-download treatment already applied to the intel report-files and RTR extracted-file-contents endpoints) and regenerate. The OK struct now exposes Payload io.Writer, and readResponse streams the body into it.