### PR TITLE
feat(report_executions): expose Content-Type and Content-Disposition on report-executions-download

### DIFF
--- a/falcon/api_client.go
+++ b/falcon/api_client.go
@@ -56,8 +56,25 @@ func NewClient(ac *ApiConfig) (*client.CrowdStrikeAPISpecification, error) {
 	customTransport.Debug = ac.Debug
 	customTransport.Consumers["application/pdf"] = httpruntime.ByteStreamConsumer()
 	customTransport.Consumers["application/x-7z-compressed"] = httpruntime.ByteStreamConsumer()
+	customTransport.Consumers["application/json"] = downloadAwareJSONConsumer()
 
 	return client.New(customTransport, strfmt.Default), nil
+}
+
+// downloadAwareJSONConsumer streams binary download payloads (io.Writer / io.ReaderFrom
+// targets) through the byte-stream consumer and decodes all other JSON responses with the
+// standard JSON consumer.
+func downloadAwareJSONConsumer() httpruntime.Consumer {
+	byteStream := httpruntime.ByteStreamConsumer()
+	jsonConsumer := httpruntime.JSONConsumer()
+	return httpruntime.ConsumerFunc(func(reader io.Reader, data any) error {
+		switch data.(type) {
+		case io.Writer, io.ReaderFrom:
+			return byteStream.Consume(reader, data)
+		default:
+			return jsonConsumer.Consume(reader, data)
+		}
+	})
 }
 
 func credentialsOk(ac *ApiConfig) (bool, error) {

--- a/falcon/api_client_test.go
+++ b/falcon/api_client_test.go
@@ -3,6 +3,7 @@ package falcon
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -591,4 +592,44 @@ func TestWaitForCooldown_PreflightDeadlineExceeded(t *testing.T) {
 	if !strings.Contains(err.Error(), "exceeds context deadline") {
 		t.Fatalf("expected descriptive error message, got: %v", err)
 	}
+}
+
+func TestDownloadAwareJSONConsumer(t *testing.T) {
+	jsonArray := `[{"a":1},{"b":2}]`
+	jsonObject := `{"n":123}`
+
+	// writerTarget cases assert raw bytes are streamed verbatim into an io.Writer,
+	// which is how the report-download endpoints pass their payload. A plain
+	// JSONConsumer would instead try to json-decode into the writer and fail.
+	t.Run("io.Writer target streams JSON array verbatim", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := downloadAwareJSONConsumer().Consume(strings.NewReader(jsonArray), &buf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if buf.String() != jsonArray {
+			t.Fatalf("expected %q, got %q", jsonArray, buf.String())
+		}
+	})
+
+	t.Run("io.Writer target streams JSON object verbatim", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := downloadAwareJSONConsumer().Consume(strings.NewReader(jsonObject), &buf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if buf.String() != jsonObject {
+			t.Fatalf("expected %q, got %q", jsonObject, buf.String())
+		}
+	})
+
+	t.Run("non-writer target decodes as JSON with UseNumber", func(t *testing.T) {
+		var out struct {
+			N json.Number `json:"n"`
+		}
+		if err := downloadAwareJSONConsumer().Consume(strings.NewReader(jsonObject), &out); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.N != json.Number("123") {
+			t.Fatalf("expected json.Number 123, got %q", out.N)
+		}
+	})
 }

--- a/falcon/client/report_executions/report_executions_download_get_responses.go
+++ b/falcon/client/report_executions/report_executions_download_get_responses.go
@@ -76,6 +76,14 @@ OK
 */
 type ReportExecutionsDownloadGetOK struct {
 
+	/* Attachment disposition carrying the report filename, e.g. attachment;filename=<report>.json
+	 */
+	ContentDisposition string
+
+	/* Media type of the downloaded report
+	 */
+	ContentType string
+
 	/* Trace-ID: submit to support if resolving an issue
 	 */
 	XCSTRACEID string
@@ -134,6 +142,20 @@ func (o *ReportExecutionsDownloadGetOK) GetPayload() io.Writer {
 }
 
 func (o *ReportExecutionsDownloadGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// hydrates response header Content-Disposition
+	hdrContentDisposition := response.GetHeader("Content-Disposition")
+
+	if hdrContentDisposition != "" {
+		o.ContentDisposition = hdrContentDisposition
+	}
+
+	// hydrates response header Content-Type
+	hdrContentType := response.GetHeader("Content-Type")
+
+	if hdrContentType != "" {
+		o.ContentType = hdrContentType
+	}
 
 	// hydrates response header X-CS-TRACEID
 	hdrXCSTRACEID := response.GetHeader("X-CS-TRACEID")

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -14,9 +14,10 @@
   # The report-executions-download 200 response carries Content-Type and Content-Disposition
   # (verified live: application/json and attachment;filename=<report>.json), but the spec declares
   # neither, so the generated OK struct drops them. A report can be delivered in different formats
-  # (produces: */*) and the Content-Disposition filename is the only signal of which one, so both
-  # headers are load-bearing for a caller that writes the body to a file. Declare them so the OK
-  # struct exposes ContentType/ContentDisposition and readResponse hydrates them.
+  # (produces: */*); Content-Type and the Content-Disposition filename let a caller detect the
+  # format straight from the download response, so both headers are load-bearing for a caller that
+  # writes the body to a file. Declare them so the OK struct exposes ContentType/ContentDisposition
+  # and readResponse hydrates them.
   | .paths."/reports/entities/report-executions-download/v1"."get"."responses"."200"."headers"."Content-Type" = {"type": "string", "description": "Media type of the downloaded report"}
   | .paths."/reports/entities/report-executions-download/v1"."get"."responses"."200"."headers"."Content-Disposition" = {"type": "string", "description": "Attachment disposition carrying the report filename, e.g. attachment;filename=<report>.json"}
   # Fix overflow on json number (more than 63 bits are needed hold this field)

--- a/specs/transformation.jq
+++ b/specs/transformation.jq
@@ -11,6 +11,14 @@
   | .paths."/intel/entities/malware-mitre-reports/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   | .paths."/real-time-response/entities/extracted-file-contents/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
   | .paths."/reports/entities/report-executions-download/v1"."get"."responses"."200"."schema"={"$ref": "#/definitions/domain.DownloadItem"}
+  # The report-executions-download 200 response carries Content-Type and Content-Disposition
+  # (verified live: application/json and attachment;filename=<report>.json), but the spec declares
+  # neither, so the generated OK struct drops them. A report can be delivered in different formats
+  # (produces: */*) and the Content-Disposition filename is the only signal of which one, so both
+  # headers are load-bearing for a caller that writes the body to a file. Declare them so the OK
+  # struct exposes ContentType/ContentDisposition and readResponse hydrates them.
+  | .paths."/reports/entities/report-executions-download/v1"."get"."responses"."200"."headers"."Content-Type" = {"type": "string", "description": "Media type of the downloaded report"}
+  | .paths."/reports/entities/report-executions-download/v1"."get"."responses"."200"."headers"."Content-Disposition" = {"type": "string", "description": "Attachment disposition carrying the report filename, e.g. attachment;filename=<report>.json"}
   # Fix overflow on json number (more than 63 bits are needed hold this field)
   | .definitions."domain.APIEvaluationLogicItemV1".properties.id."x-go-type"={type: "Number", import: {package: "encoding/json"}, hints: {noValidation: true}}
   | .definitions."domain.APISimplifiedEvaluationLogicItemV1".properties.id."x-go-type"={type: "Number", import: {package: "encoding/json"}, hints: {noValidation: true}}


### PR DESCRIPTION
The report-executions-download 200 response carries Content-Type and Content-Disposition (verified live: application/json and attachment;filename=<report>.json), but the spec declared neither, so the generated OK struct dropped them. A report can be delivered in different formats (produces: */*) and the Content-Disposition filename is the only signal of which one, so both headers are load-bearing for a caller writing the body to a file.